### PR TITLE
docs: add local development steps to frontend README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,15 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Local development
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm run dev
+```
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh


### PR DESCRIPTION
### Motivation
- Provide quick start instructions so contributors can run the frontend locally using `npm install` and `npm run dev`.

### Description
- Created branch `codex` and added a "Local development" section to `frontend/README.md` containing the commands `npm install` and `npm run dev`, then committed the change with message `docs: add local development steps to frontend README`.

### Testing
- Ran `git status --short --branch`, `git add frontend/README.md`, and `git commit -m "docs: add local development steps to frontend README"`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4956c4ff4833292ad614f2fa50548)