### PR TITLE
Fix password input styling in Login screen

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -402,6 +402,7 @@ tr:hover td {
 input[type="text"],
 input[type="number"],
 input[type="email"],
+input[type="password"],
 select,
 textarea {
   width: 100%;


### PR DESCRIPTION
The user requested that the login screen be made "clean and neat." After inspecting the application, I found that the `password` input field was unstyled compared to the `username` (text) input field, causing inconsistent sizes and padding in the login form.

I updated `frontend/src/index.css` to include `input[type="password"]` in the same CSS rule block as `input[type="text"]`, `input[type="email"]`, etc. This aligns the appearance of the password input with the rest of the form fields across the application.

I verified this fix locally by spinning up the application, loading the login screen using a Playwright script, and reviewing the screenshot to ensure the UI is clean and neat. I also ran `npm run build` to verify that there are no regressions.

---
*PR created automatically by Jules for task [4104458486639141099](https://jules.google.com/task/4104458486639141099) started by @millennialperfumer-tech*