### PR TITLE
🛡️ Sentinel: [HIGH] Fix WhatsApp Webhook verification bypass

### DIFF
--- a/backend/internal/automation/whatsapp/handlers.go
+++ b/backend/internal/automation/whatsapp/handlers.go
@@ -3,6 +3,7 @@ package whatsapp
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -138,12 +139,26 @@ func (h *AutomationHandler) SyncTemplateStatus(w http.ResponseWriter, r *http.Re
 func (h *AutomationHandler) WhatsAppWebhook(w http.ResponseWriter, r *http.Request) {
 	// 1. Hub Challenge for verification
 	if r.Method == http.MethodGet {
+		mode := r.URL.Query().Get("hub.mode")
+		token := r.URL.Query().Get("hub.verify_token")
 		challenge := r.URL.Query().Get("hub.challenge")
-		if challenge != "" {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(challenge))
+
+		if mode != "" && token != "" {
+			expectedToken := h.settings.GetWhatsAppWebhookVerifyToken()
+			if mode == "subscribe" && subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1 {
+				log.Printf("WhatsApp Webhook verified successfully")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(challenge))
+				return
+			}
+			log.Printf("WhatsApp Webhook verification failed: mode=%s", mode)
+			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}
+
+		log.Printf("WhatsApp Webhook verification failed: missing parameters")
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
 	}
 
 	// 2. Handle status updates

--- a/backend/internal/automation/whatsapp/handlers_test.go
+++ b/backend/internal/automation/whatsapp/handlers_test.go
@@ -1,0 +1,46 @@
+package whatsapp
+
+import (
+	"mi-tech/internal/config"
+	"mi-tech/internal/repository"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestWhatsAppWebhookVerification(t *testing.T) {
+	db, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	db.AutoMigrate(&repository.AppConfig{})
+	configsRepo := repository.NewConfigsRepository(db)
+
+	expectedToken := "my_secure_token"
+	configsRepo.Set("whatsapp_webhook_verify_token", expectedToken)
+	handler := &AutomationHandler{settings: config.NewSettingsProvider(configsRepo)}
+
+	cases := []struct {
+		name, query string
+		expCode     int
+		expBody     string
+	}{
+		{"Valid", "hub.mode=subscribe&hub.verify_token=" + expectedToken + "&hub.challenge=1234", 200, "1234"},
+		{"Invalid token", "hub.mode=subscribe&hub.verify_token=wrong&hub.challenge=1234", 403, ""},
+		{"Invalid mode", "hub.mode=wrong&hub.verify_token=" + expectedToken + "&hub.challenge=1234", 403, ""},
+		{"Missing params", "hub.challenge=1234", 403, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/api/automation/whatsapp/webhook?"+tc.query, nil)
+			rr := httptest.NewRecorder()
+			handler.WhatsAppWebhook(rr, req)
+			assert.Equal(t, tc.expCode, rr.Code)
+			if tc.expBody != "" {
+				assert.Equal(t, tc.expBody, rr.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implemented WhatsApp Webhook verification by validating the 'hub.verify_token' and 'hub.mode' parameters in the GET request. Previously, the endpoint was failing open by returning the 'hub.challenge' regardless of the token. The fix uses 'subtle.ConstantTimeCompare' for secure token validation and ensures that only 'subscribe' requests with the correct token are honored. Added unit tests to verify the fix and prevent regressions.

---
*PR created automatically by Jules for task [10331123560109549192](https://jules.google.com/task/10331123560109549192) started by @millennialperfumer-tech*