### PR TITLE
🛡️ Sentinel: [HIGH] Fix authentication identity mismatch in Config Reveal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Permissive CORS policy echoing back any `Origin` header and setting `Access-Control-Allow-Credentials: true`.
 **Learning:** This "reflect-all" pattern effectively bypasses CORS protections, allowing any third-party domain to make authenticated requests to the API on behalf of a user.
 **Prevention:** Implement a strict allowlist for the `Origin` header and only set `Access-Control-Allow-Credentials: true` for trusted origins.
+
+## 2026-03-26 - [Authentication Identity Mismatch in Config Reveal]
+**Vulnerability:** `ConfigsHandler.RevealConfigs` verified the admin password against the first user in the `users` table instead of the authenticated user performing the request.
+**Learning:** Relying on `First()` for sensitive credential verification without an explicit user identifier allows any authenticated user with access to the endpoint to succeed by providing the password of the "first" user (likely the original admin), bypassing individual accountability and potentially allowing horizontal or vertical privilege escalation if the "first" user has different permissions.
+**Prevention:** Always extract and use the authenticated user's identity from the request context to fetch their specific credentials for verification.

--- a/backend/internal/handler/configs_handler.go
+++ b/backend/internal/handler/configs_handler.go
@@ -51,16 +51,23 @@ func (h *ConfigsHandler) RevealConfigs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate password against the users table (same as login)
+	// Get username from context
+	username, ok := r.Context().Value("username").(string)
+	if !ok || username == "" {
+		http.Error(w, "Unauthorized: user identity not found", http.StatusUnauthorized)
+		return
+	}
+
+	// Validate password against the users table for the CURRENT user
 	var user struct {
 		PasswordHash string `gorm:"column:password_hash"`
 	}
-	if err := h.db.Table("users").Select("password_hash").First(&user).Error; err != nil {
+	if err := h.db.Table("users").Select("password_hash").Where("username = ?", username).First(&user).Error; err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"success": false,
-			"message": "No admin user found",
+			"message": "User not found",
 		})
 		return
 	}

--- a/backend/internal/server/middleware.go
+++ b/backend/internal/server/middleware.go
@@ -89,9 +89,12 @@ func AuthMiddleware(authService *service.AuthService) func(http.Handler) http.Ha
 				role = "read" // default fallback
 			}
 
-			// Add role to context
-			log.Printf("AuthMiddleware: user=%s role=%s", claims["username"], role)
+			username, _ := claims["username"].(string)
+
+			// Add role and username to context
+			log.Printf("AuthMiddleware: user=%s role=%s", username, role)
 			ctx := context.WithValue(r.Context(), "userRole", role)
+			ctx = context.WithValue(ctx, "username", username)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `ConfigsHandler.RevealConfigs` verified the provided password against the first user in the `users` table, rather than the authenticated user making the request.
🎯 Impact: This allowed any admin user to potentially "masquerade" as the original admin (usually the first user created) for the purpose of revealing secrets, or failed to correctly identify which user's password was being checked.
🔧 Fix:
1. Updated `AuthMiddleware` to inject the `username` claim from the JWT into the request context.
2. Modified `ConfigsHandler.RevealConfigs` to retrieve the `username` from the context and verify the password against that specific user's hash in the database.
✅ Verification:
- Verified that `AuthMiddleware` now correctly propagates the `username`.
- Verified that `RevealConfigs` uses the context `username` for its database query.
- Ran `cd backend && go test ./...` and all tests passed.

---
*PR created automatically by Jules for task [127654426378381370](https://jules.google.com/task/127654426378381370) started by @millennialperfumer-tech*