### PR TITLE
🎨 Palette: Add "Clear Search" buttons to search inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - [Accessible Dropdown & Global Focus States]
 **Learning:** For apps with a custom design system that disables default focus outlines, a global `:focus-visible` style is a crucial accessibility win that doesn't compromise visual design for mouse users. Component-level accessibility for dropdowns requires both ARIA roles/attributes and keyboard event listeners (like Escape) to be truly inclusive.
 **Action:** Always check `index.css` for `outline: none` and ensure `:focus-visible` is implemented. When building popovers/dropdowns, use the `useEffect` hook to manage global keyboard listeners for the `Escape` key.
+
+## 2025-05-16 - [Search 'Clear' Button Pattern]
+**Learning:** Search 'Clear' buttons must reset both the search query and the pagination state (e.g., `setPage(1)`) to avoid displaying empty results on high page numbers after the filter is cleared.
+**Action:** Always include `setPage(1)` (or equivalent pagination reset) in clear button click handlers. Explicitly set `border: 'none'` and `background: 'transparent'` for such buttons to ensure cross-browser visual consistency.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -980,6 +980,7 @@ function App() {
                     onChange={(e) => { setSearch(e.target.value); setPage(1); }}
                     style={{ 
                       paddingLeft: '2.5rem', 
+                      paddingRight: search ? '2.5rem' : '1rem',
                       fontSize: '0.875rem', 
                       background: 'transparent',
                       border: 'none',
@@ -987,6 +988,42 @@ function App() {
                       width: '100%'
                     }}
                   />
+                  {search && (
+                    <button
+                      onClick={() => { setSearch(''); setPage(1); }}
+                      aria-label="Clear search"
+                      title="Clear search"
+                      style={{
+                        position: 'absolute',
+                        right: '12px',
+                        top: '50%',
+                        transform: 'translateY(-50%)',
+                        color: 'var(--text-tertiary)',
+                        padding: '4px',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        borderRadius: '50%',
+                        transition: 'all 0.2s',
+                        cursor: 'pointer',
+                        border: 'none',
+                        background: 'transparent'
+                      }}
+                      onMouseEnter={(e) => {
+                        e.currentTarget.style.color = 'var(--text-primary)';
+                        e.currentTarget.style.background = 'var(--bg-hover)';
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.color = 'var(--text-tertiary)';
+                        e.currentTarget.style.background = 'transparent';
+                      }}
+                    >
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                      </svg>
+                    </button>
+                  )}
                 </div>
                 
                 <select 

--- a/frontend/src/Customers.tsx
+++ b/frontend/src/Customers.tsx
@@ -545,8 +545,44 @@ export function Customers({ fetchWithAuth, showClearButton = false, bulkSuffix =
                             aria-label="Search customers"
                             value={search}
                             onChange={(e) => { setSearch(e.target.value); setPage(1); }}
-                            style={{ paddingLeft: '2.5rem', width: '100%' }}
+                            style={{ paddingLeft: '2.5rem', paddingRight: search ? '2.5rem' : '1rem', width: '100%' }}
                         />
+                        {search && (
+                            <button
+                                onClick={() => { setSearch(''); setPage(1); }}
+                                aria-label="Clear search"
+                                title="Clear search"
+                                style={{
+                                    position: 'absolute',
+                                    right: '12px',
+                                    top: '50%',
+                                    transform: 'translateY(-50%)',
+                                    color: 'var(--text-tertiary)',
+                                    padding: '4px',
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    borderRadius: '50%',
+                                    transition: 'all 0.2s',
+                                    cursor: 'pointer',
+                                    border: 'none',
+                                    background: 'transparent'
+                                }}
+                                onMouseEnter={(e) => {
+                                    e.currentTarget.style.color = 'var(--text-primary)';
+                                    e.currentTarget.style.background = 'var(--bg-hover)';
+                                }}
+                                onMouseLeave={(e) => {
+                                    e.currentTarget.style.color = 'var(--text-tertiary)';
+                                    e.currentTarget.style.background = 'transparent';
+                                }}
+                            >
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                                    <line x1="18" y1="6" x2="6" y2="18"></line>
+                                    <line x1="6" y1="6" x2="18" y2="18"></line>
+                                </svg>
+                            </button>
+                        )}
                     </div>
                     <div style={{ display: 'flex', gap: '1rem', position: 'relative' }}>
                         <button 


### PR DESCRIPTION
💡 What:
- Added a conditional "Clear" button (X) inside the search input container for both Customers and Orders views.
- The button is only visible when the search field contains text.
- Clicking the button resets the search query and resets pagination to page 1.

🎯 Why:
- Improves user productivity by allowing one-click resets of complex search queries.
- Prevents "empty results" bugs where a user might be on page 10 and clear their search, but remain on page 10 where no records exist in the unfiltered set.

📸 Before/After:
- Before: Users had to manually delete text or select-all and backspace to clear searches.
- After: A sleek 'X' button appears at the right of the input for immediate clearing.

♻️ Accessibility:
- Semantic button elements with `aria-label="Clear search"` and `title="Clear search"`.
- Keyboard accessible (focusable and clickable).
- Visible focus states via global `:focus-visible` styles.
- Maintained sufficient click target size.

Verification:
- Verified via Playwright screenshots.
- Confirmed that `pnpm build` passes.
- Cleaned up `pnpm-lock.yaml` and temporary verification scripts.

---
*PR created automatically by Jules for task [453883289190036029](https://jules.google.com/task/453883289190036029) started by @millennialperfumer-tech*