### PR TITLE
⚡ Bolt: Optimize GST Reporting Queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2026-03-27 - [Batching Line Item Upserts]
 **Learning:** Iterative database operations within repository methods (like looping over line items to perform individual upserts) create significant overhead due to multiple database roundtrips. Even when using transactions, the per-row execution time adds up. GORM's native batch insert (`tx.Create(&slice)`) reduces this to a single O(1) roundtrip.
 **Action:** Always prefer batch operations (`Create`, `Save`) with slices instead of loops when handling child entities or bulk datasets in GORM. Ensure slice elements are updated by index (`for i := range slice`) before the batch call.
+
+## 2026-03-27 - [Optimizing Reporting with SQL Aggregations and Window Functions]
+**Learning:** Combining multiple metrics into a single SQL query using `FILTER` and `CASE` (conditional aggregation) eliminates redundant database roundtrips and application-side processing. For HSN/line-item reports, replacing global CTE scans with window functions (`SUM(...) OVER (PARTITION BY order_id)`) within date-filtered JOINs ensures the database only processes relevant rows, significantly improving performance as the table grows.
+**Action:** Always prefer conditional SQL aggregation over multiple repository calls for dashboard/reporting logic. Use window functions for per-group aggregations within filtered result sets to avoid full table scans.

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -19,7 +19,7 @@ func main() {
 	configsRepo := repository.NewConfigsRepository(db)
 	settingsProvider := config.NewSettingsProvider(configsRepo)
 
-	authService := service.NewAuthService(db, settingsProvider)
+	authService := service.NewAuthService(db, settingsProvider, nil)
 
 	username := os.Getenv("ADMIN_USERNAME")
 	if username == "" {

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -66,14 +66,27 @@ type MetricsRepository interface {
 
 // ReportRepository defines data access for GST report queries.
 type ReportRepository interface {
-	GetGSTSummary(startDate, endDate string) (totalOrders, cancelledOrders, fulfilledOrders, unfulfilledOrders, paidOrders int, totalRevenue, totalTaxable, totalTax float64, err error)
+	GetGSTSummary(startDate, endDate string) (GSTSummaryResult, error)
 	GetStateSummary(startDate, endDate string) (results []StateSummaryResult, err error)
 	GetHSNSummary(startDate, endDate string) (results []HSNSummaryResult, err error)
 	GetDocumentsIssued(startDate, endDate string) (minOrder, maxOrder *int64, total, cancelled int, err error)
-	GetTaxByState(startDate, endDate string) (results []StateTaxResult, err error)
 }
 
 // --- Result structs used by ReportRepository ---
+
+type GSTSummaryResult struct {
+	TotalOrders       int
+	CancelledOrders   int
+	FulfilledOrders   int
+	UnfulfilledOrders int
+	PaidOrders        int
+	TotalRevenue      float64
+	TotalTaxable      float64
+	TotalTax          float64
+	CGST              float64
+	SGST              float64
+	IGST              float64
+}
 
 type StateSummaryResult struct {
 	State        string
@@ -93,7 +106,3 @@ type HSNSummaryResult struct {
 	Revenue      float64
 }
 
-type StateTaxResult struct {
-	State string
-	Tax   float64
-}

--- a/backend/internal/repository/report_repository.go
+++ b/backend/internal/repository/report_repository.go
@@ -66,7 +66,7 @@ func NewReportRepository(db *gorm.DB) ReportRepository {
 	return &gormReportRepository{db: db}
 }
 
-func (r *gormReportRepository) GetGSTSummary(startDate, endDate string) (totalOrders, cancelledOrders, fulfilledOrders, unfulfilledOrders, paidOrders int, totalRevenue, totalTaxable, totalTax float64, err error) {
+func (r *gormReportRepository) GetGSTSummary(startDate, endDate string) (GSTSummaryResult, error) {
 	start, end := parseDateRange(startDate, endDate)
 
 	query := `
@@ -78,36 +78,27 @@ func (r *gormReportRepository) GetGSTSummary(startDate, endDate string) (totalOr
 			COUNT(id) FILTER (WHERE LOWER(financial_status) = 'paid'),
 			COALESCE(SUM(total_price) FILTER (WHERE status IS NULL OR LOWER(status) != 'cancelled'), 0) as revenue,
 			COALESCE(SUM(ROUND(total_price / 1.18, 2)) FILTER (WHERE status IS NULL OR LOWER(status) != 'cancelled'), 0) as taxable,
-			COALESCE(SUM(total_price - ROUND(total_price / 1.18, 2)) FILTER (WHERE status IS NULL OR LOWER(status) != 'cancelled'), 0) as tax
+			COALESCE(SUM(total_price - ROUND(total_price / 1.18, 2)) FILTER (WHERE status IS NULL OR LOWER(status) != 'cancelled'), 0) as tax,
+			COALESCE(SUM(CASE WHEN LOWER(customer_state) IN ('tamil nadu', 'tn', 'tamilnadu') THEN (total_price - ROUND(total_price / 1.18, 2)) / 2 ELSE 0 END) FILTER (WHERE status IS NULL OR LOWER(status) != 'cancelled'), 0) as cgst,
+			COALESCE(SUM(CASE WHEN LOWER(customer_state) IN ('tamil nadu', 'tn', 'tamilnadu') THEN (total_price - ROUND(total_price / 1.18, 2)) / 2 ELSE 0 END) FILTER (WHERE status IS NULL OR LOWER(status) != 'cancelled'), 0) as sgst,
+			COALESCE(SUM(CASE WHEN LOWER(customer_state) NOT IN ('tamil nadu', 'tn', 'tamilnadu') THEN (total_price - ROUND(total_price / 1.18, 2)) ELSE 0 END) FILTER (WHERE status IS NULL OR LOWER(status) != 'cancelled'), 0) as igst
 		FROM orders 
 		WHERE created_at >= ? AND created_at <= ?
 	`
 
-	type summaryResult struct {
-		TotalOrders       int
-		CancelledOrders   int
-		FulfilledOrders   int
-		UnfulfilledOrders int
-		PaidOrders        int
-		Revenue           float64
-		Taxable           float64
-		Tax               float64
-	}
-
-	var result summaryResult
+	var result GSTSummaryResult
 	row := r.db.Raw(query, start, end).Row()
-	err = row.Scan(
+	err := row.Scan(
 		&result.TotalOrders, &result.CancelledOrders, &result.FulfilledOrders,
 		&result.UnfulfilledOrders, &result.PaidOrders,
-		&result.Revenue, &result.Taxable, &result.Tax,
+		&result.TotalRevenue, &result.TotalTaxable, &result.TotalTax,
+		&result.CGST, &result.SGST, &result.IGST,
 	)
 	if err != nil {
-		return
+		return GSTSummaryResult{}, err
 	}
 
-	return result.TotalOrders, result.CancelledOrders, result.FulfilledOrders,
-		result.UnfulfilledOrders, result.PaidOrders,
-		result.Revenue, result.Taxable, result.Tax, nil
+	return result, nil
 }
 
 func (r *gormReportRepository) GetStateSummary(startDate, endDate string) ([]StateSummaryResult, error) {
@@ -137,24 +128,18 @@ func (r *gormReportRepository) GetHSNSummary(startDate, endDate string) ([]HSNSu
 	start, end := parseDateRange(startDate, endDate)
 
 	query := `
-		WITH OrderSubtotals AS (
-			SELECT order_id, SUM(price * quantity - discount) as line_sum
-			FROM order_line_items
-			GROUP BY order_id
-		),
-		LineItemShares AS (
+		WITH LineItemShares AS (
 			SELECT 
 				li.order_id,
 				COALESCE(li.hs_code, '33029019') as hs_code,
 				li.quantity,
 				(li.price * li.quantity - li.discount) as line_val,
-				os.line_sum,
+				SUM(li.price * li.quantity - li.discount) OVER (PARTITION BY li.order_id) as line_sum,
 				o.total_price,
 				COALESCE(o.customer_state, 'N/A') as state
 			FROM order_line_items li
 			JOIN orders o ON li.order_id = o.id
-			JOIN OrderSubtotals os ON li.order_id = os.order_id
-			WHERE o.created_at >= ? AND o.created_at <= ? AND (o.status IS NULL OR LOWER(o.status) != 'cancelled') AND os.line_sum > 0
+			WHERE o.created_at >= ? AND o.created_at <= ? AND (o.status IS NULL OR LOWER(o.status) != 'cancelled')
 		)
 		SELECT 
 			hs_code as hsn_code,
@@ -165,6 +150,7 @@ func (r *gormReportRepository) GetHSNSummary(startDate, endDate string) ([]HSNSu
 			SUM(ROUND((line_val / line_sum) * total_price, 2)) as revenue,
 			state
 		FROM LineItemShares
+		WHERE line_sum > 0
 		GROUP BY hs_code, state
 		ORDER BY revenue DESC
 	`
@@ -204,24 +190,6 @@ func (r *gormReportRepository) GetDocumentsIssued(startDate, endDate string) (mi
 	return
 }
 
-func (r *gormReportRepository) GetTaxByState(startDate, endDate string) ([]StateTaxResult, error) {
-	start, end := parseDateRange(startDate, endDate)
-
-	query := `
-		SELECT 
-			COALESCE(customer_state, 'N/A') as state,
-			SUM(total_price - ROUND(total_price / 1.18, 2)) as tax
-		FROM orders
-		WHERE created_at >= ? AND created_at <= ? AND (status IS NULL OR LOWER(status) != 'cancelled')
-		GROUP BY customer_state
-	`
-
-	var results []StateTaxResult
-	if err := r.db.Raw(query, start, end).Scan(&results).Error; err != nil {
-		return nil, fmt.Errorf("failed to query tax by state: %w", err)
-	}
-	return results, nil
-}
 
 // --- Shared helper ---
 

--- a/backend/internal/repository/report_repository_test.go
+++ b/backend/internal/repository/report_repository_test.go
@@ -79,13 +79,16 @@ func (s *MetricsReportRepositoryTestSuite) TestGetGSTSummary() {
 		ExternalOrderID: "r1", TotalPrice: 118.0, CustomerState: &tn, FinancialStatus: entity.StrPtr("paid"), CreatedAt: time.Now(),
 	})
 
-	total, _, _, _, paid, rev, taxable, tax, err := s.reportRepo.GetGSTSummary("", now)
+	res, err := s.reportRepo.GetGSTSummary("", now)
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), 1, total)
-	assert.Equal(s.T(), 1, paid)
-	assert.Equal(s.T(), 118.0, rev)
-	assert.Equal(s.T(), 100.0, taxable)
-	assert.Equal(s.T(), 18.0, tax)
+	assert.Equal(s.T(), 1, res.TotalOrders)
+	assert.Equal(s.T(), 1, res.PaidOrders)
+	assert.Equal(s.T(), 118.0, res.TotalRevenue)
+	assert.Equal(s.T(), 100.0, res.TotalTaxable)
+	assert.Equal(s.T(), 18.0, res.TotalTax)
+	assert.Equal(s.T(), 9.0, res.CGST)
+	assert.Equal(s.T(), 9.0, res.SGST)
+	assert.Equal(s.T(), 0.0, res.IGST)
 }
 
 func (s *MetricsReportRepositoryTestSuite) TestGetStateSummary() {
@@ -106,6 +109,44 @@ func (s *MetricsReportRepositoryTestSuite) TestGetStateSummary() {
 			assert.Equal(s.T(), 300.0, r.Revenue)
 		}
 	}
+}
+
+func (s *MetricsReportRepositoryTestSuite) TestGetHSNSummary() {
+	now := time.Now().Format(time.RFC3339)
+	tn := "Tamil Nadu"
+
+	// Create order
+	order := entity.Order{
+		ExternalOrderID: "h1",
+		TotalPrice:      118.0,
+		CustomerState:   &tn,
+		CreatedAt:       time.Now(),
+	}
+	s.db.Create(&order)
+
+	// Create line items
+	s.db.Create(&entity.LineItem{
+		OrderID:  order.ID,
+		HSCode:   entity.StrPtr("123456"),
+		Price:    100.0,
+		Quantity: 1,
+		Discount: 0,
+	})
+
+	results, err := s.reportRepo.GetHSNSummary("", now)
+	assert.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), results)
+
+	found := false
+	for _, r := range results {
+		if r.HSNCode == "123456" {
+			found = true
+			assert.Equal(s.T(), 100.0, r.TaxableValue)
+			assert.Equal(s.T(), 18.0, r.TotalGST)
+			assert.Equal(s.T(), 118.0, r.Revenue)
+		}
+	}
+	assert.True(s.T(), found)
 }
 
 func TestMetricsReportRepositorySuite(t *testing.T) {

--- a/backend/internal/service/report_service.go
+++ b/backend/internal/service/report_service.go
@@ -20,35 +20,24 @@ func NewReportService(reportRepo repository.ReportRepository) *ReportService {
 
 // GetGSTSummary computes the full GST summary including CGST/SGST/IGST splits by state.
 func (s *ReportService) GetGSTSummary(startDate, endDate string) (dto.GSTSummaryResponse, error) {
-	totalOrders, cancelledOrders, fulfilledOrders, unfulfilledOrders, paidOrders,
-		totalRevenue, totalTaxable, totalTax, err := s.reportRepo.GetGSTSummary(startDate, endDate)
+	res, err := s.reportRepo.GetGSTSummary(startDate, endDate)
 	if err != nil {
 		return dto.GSTSummaryResponse{}, err
 	}
 
 	summary := dto.GSTSummaryResponse{
-		TotalOrders:       totalOrders,
-		CancelledOrders:   cancelledOrders,
-		InvoicesGenerated: totalOrders - cancelledOrders,
-		TotalRevenue:      totalRevenue,
-		TotalTaxableValue: totalTaxable,
-		TotalGSTCollected: totalTax,
-		FulfilledOrders:   fulfilledOrders,
-		UnfulfilledOrders: unfulfilledOrders,
-		PaidOrders:        paidOrders,
-	}
-
-	// Split tax by state: Tamil Nadu = CGST+SGST, others = IGST
-	taxByState, err := s.reportRepo.GetTaxByState(startDate, endDate)
-	if err == nil {
-		for _, st := range taxByState {
-			if isTamilNadu(st.State) {
-				summary.TotalCGST += st.Tax / 2
-				summary.TotalSGST += st.Tax / 2
-			} else {
-				summary.TotalIGST += st.Tax
-			}
-		}
+		TotalOrders:       res.TotalOrders,
+		CancelledOrders:   res.CancelledOrders,
+		InvoicesGenerated: res.TotalOrders - res.CancelledOrders,
+		TotalRevenue:      res.TotalRevenue,
+		TotalTaxableValue: res.TotalTaxable,
+		TotalGSTCollected: res.TotalTax,
+		TotalCGST:         res.CGST,
+		TotalSGST:         res.SGST,
+		TotalIGST:         res.IGST,
+		FulfilledOrders:   res.FulfilledOrders,
+		UnfulfilledOrders: res.UnfulfilledOrders,
+		PaidOrders:        res.PaidOrders,
 	}
 
 	return summary, nil


### PR DESCRIPTION
⚡ Bolt: Optimize GST Reporting Queries

💡 What:
- Optimized GST summary and HSN summary database queries.
- Combined GST summary and tax split calculations into a single SQL query using conditional aggregation (`FILTER` and `CASE`).
- Refactored `GetHSNSummary` to use a window function (`SUM(...) OVER (PARTITION BY order_id)`) instead of a global CTE scan, ensuring it only processes orders within the requested date range.
- Refactored `GetGSTSummary` return signature to use a struct (`GSTSummaryResult`) for better maintainability.
- Removed unused `GetTaxByState` method and associated `StateTaxResult` struct.
- Fixed a compilation error in `cmd/seed/main.go`.

🎯 Why:
The previous reporting logic performed redundant database scans and roundtrips. Specifically, `GetHSNSummary` was scanning the entire `order_line_items` table regardless of date filters, which would become a major bottleneck as the dataset grew.

📊 Impact:
- Reduces database roundtrips for GST summary from 2 to 1.
- Significant reduction in database scans for HSN summary (from O(TotalRows) to O(FilteredRows)).
- Improved code maintainability through better type safety (struct instead of multiple return values).

🔬 Measurement:
Verified through `go build ./...` and updated repository unit tests. Expected performance improvement is proportional to the size of the database, especially as order history grows.

---
*PR created automatically by Jules for task [2319701037255438251](https://jules.google.com/task/2319701037255438251) started by @millennialperfumer-tech*