### PR TITLE
⚡ Bolt: optimize HSN summary query performance

### DIFF
--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -19,7 +19,7 @@ func main() {
 	configsRepo := repository.NewConfigsRepository(db)
 	settingsProvider := config.NewSettingsProvider(configsRepo)
 
-	authService := service.NewAuthService(db, settingsProvider)
+	authService := service.NewAuthService(db, settingsProvider, nil)
 
 	username := os.Getenv("ADMIN_USERNAME")
 	if username == "" {

--- a/backend/internal/repository/report_repository.go
+++ b/backend/internal/repository/report_repository.go
@@ -136,35 +136,32 @@ func (r *gormReportRepository) GetStateSummary(startDate, endDate string) ([]Sta
 func (r *gormReportRepository) GetHSNSummary(startDate, endDate string) ([]HSNSummaryResult, error) {
 	start, end := parseDateRange(startDate, endDate)
 
+	// Optimization: Replaces global CTE with window function to avoid full table scan of order_line_items.
+	// We only calculate subtotals for the orders within the date range.
 	query := `
-		WITH OrderSubtotals AS (
-			SELECT order_id, SUM(price * quantity - discount) as line_sum
-			FROM order_line_items
-			GROUP BY order_id
-		),
-		LineItemShares AS (
+		WITH LineItemShares AS (
 			SELECT 
 				li.order_id,
 				COALESCE(li.hs_code, '33029019') as hs_code,
 				li.quantity,
 				(li.price * li.quantity - li.discount) as line_val,
-				os.line_sum,
+				SUM(li.price * li.quantity - li.discount) OVER (PARTITION BY li.order_id) as line_sum,
 				o.total_price,
 				COALESCE(o.customer_state, 'N/A') as state
 			FROM order_line_items li
 			JOIN orders o ON li.order_id = o.id
-			JOIN OrderSubtotals os ON li.order_id = os.order_id
-			WHERE o.created_at >= ? AND o.created_at <= ? AND (o.status IS NULL OR LOWER(o.status) != 'cancelled') AND os.line_sum > 0
+			WHERE o.created_at >= ? AND o.created_at <= ? AND (o.status IS NULL OR LOWER(o.status) != 'cancelled')
 		)
 		SELECT 
 			hs_code as hsn_code,
 			COUNT(DISTINCT order_id) as product_count,
 			SUM(quantity) as qty_sold,
-			SUM(ROUND((line_val / line_sum) * (total_price / 1.18), 2)) as taxable_value,
-			SUM(ROUND((line_val / line_sum) * total_price, 2) - ROUND((line_val / line_sum) * (total_price / 1.18), 2)) as total_gst,
-			SUM(ROUND((line_val / line_sum) * total_price, 2)) as revenue,
+			SUM(ROUND((line_val / NULLIF(line_sum, 0)) * (total_price / 1.18), 2)) as taxable_value,
+			SUM(ROUND((line_val / NULLIF(line_sum, 0)) * total_price, 2) - ROUND((line_val / NULLIF(line_sum, 0)) * (total_price / 1.18), 2)) as total_gst,
+			SUM(ROUND((line_val / NULLIF(line_sum, 0)) * total_price, 2)) as revenue,
 			state
 		FROM LineItemShares
+		WHERE line_sum > 0
 		GROUP BY hs_code, state
 		ORDER BY revenue DESC
 	`

--- a/backend/internal/repository/report_repository_test.go
+++ b/backend/internal/repository/report_repository_test.go
@@ -108,6 +108,56 @@ func (s *MetricsReportRepositoryTestSuite) TestGetStateSummary() {
 	}
 }
 
+func (s *MetricsReportRepositoryTestSuite) TestGetHSNSummary() {
+	now := time.Now().Format(time.RFC3339)
+	tn := "Tamil Nadu"
+	hsn1 := "123456"
+	hsn2 := "789012"
+
+	// Order 1: TN, Total 118, 2 line items
+	o1 := entity.Order{
+		ExternalOrderID: "o1", TotalPrice: 118.0, CustomerState: &tn, CreatedAt: time.Now(),
+	}
+	s.db.Create(&o1)
+	s.db.Create(&entity.LineItem{ID: "li1", OrderID: o1.ID, HSCode: &hsn1, Quantity: 1, Price: 50.0})
+	s.db.Create(&entity.LineItem{ID: "li2", OrderID: o1.ID, HSCode: &hsn2, Quantity: 1, Price: 50.0})
+
+	// Order 2: TN, Total 236, 1 line item (same HSN as li1)
+	o2 := entity.Order{
+		ExternalOrderID: "o2", TotalPrice: 236.0, CustomerState: &tn, CreatedAt: time.Now(),
+	}
+	s.db.Create(&o2)
+	s.db.Create(&entity.LineItem{ID: "li3", OrderID: o2.ID, HSCode: &hsn1, Quantity: 2, Price: 100.0})
+
+	results, err := s.reportRepo.GetHSNSummary("", now)
+	assert.NoError(s.T(), err)
+
+	// Expectations:
+	// HSN 123456:
+	//   Order 1 share: line_val=50, line_sum=100. taxable = (50/100)*(118/1.18) = 50. revenue = (50/100)*118 = 59. qty = 1
+	//   Order 2 share: line_val=200, line_sum=200. taxable = (200/200)*(236/1.18) = 200. revenue = (200/200)*236 = 236. qty = 2
+	//   Total taxable = 250, Total revenue = 295, Total qty = 3, Product count = 2
+
+	// HSN 789012:
+	//   Order 1 share: line_val=50, line_sum=100. taxable = (50/100)*(118/1.18) = 50. revenue = (50/100)*118 = 59. qty = 1
+	//   Total taxable = 50, Total revenue = 59, Total qty = 1, Product count = 1
+
+	assert.Equal(s.T(), 2, len(results))
+	for _, r := range results {
+		if r.HSNCode == hsn1 {
+			assert.Equal(s.T(), 3, r.QtySold)
+			assert.Equal(s.T(), 2, r.ProductCount)
+			assert.InDelta(s.T(), 250.0, r.TaxableValue, 0.01)
+			assert.InDelta(s.T(), 295.0, r.Revenue, 0.01)
+		} else if r.HSNCode == hsn2 {
+			assert.Equal(s.T(), 1, r.QtySold)
+			assert.Equal(s.T(), 1, r.ProductCount)
+			assert.InDelta(s.T(), 50.0, r.TaxableValue, 0.01)
+			assert.InDelta(s.T(), 59.0, r.Revenue, 0.01)
+		}
+	}
+}
+
 func TestMetricsReportRepositorySuite(t *testing.T) {
 	suite.Run(t, new(MetricsReportRepositoryTestSuite))
 }

--- a/backend/internal/service/auth_service_test.go
+++ b/backend/internal/service/auth_service_test.go
@@ -17,9 +17,9 @@ func TestAuthService_Login(t *testing.T) {
 	}
 	defer testutil.CleanupTestDB(db)
 
-	service := NewAuthService(db, nil)
+	service := NewAuthService(db, nil, nil)
 
-	_, err = service.Login("admin@millennialperfumer.in", "admin123")
+	_, _, err = service.Login("admin@millennialperfumer.in", "admin123")
 
 	if err != nil {
 		// We expect an error about nil settings if it tries to GenerateToken
@@ -34,7 +34,7 @@ func TestAuthService_Register(t *testing.T) {
 	}
 	defer testutil.CleanupTestDB(db)
 
-	service := NewAuthService(db, nil)
+	service := NewAuthService(db, nil, nil)
 	err = service.Register("newuser@example.com", "password123")
 	assert.NoError(t, err)
 


### PR DESCRIPTION
💡 What: Optimized the `GetHSNSummary` query in `ReportRepository` by replacing a global Common Table Expression (CTE) with a window function (`SUM(...) OVER (PARTITION BY li.order_id)`) inside a filtered subquery.

🎯 Why: The original query performed a full table scan and global aggregation of the `order_line_items` table before filtering by date. This caused linear performance degradation as the total number of line items in the database grew, even for small date ranges.

📊 Impact: Reduces query execution time from O(Total Line Items) to O(Filtered Line Items). For databases with a large history but small report ranges (e.g. monthly GST), this results in a significant speedup (e.g. ~90% reduction in rows scanned if reporting on 1 month out of a year).

🔬 Measurement: Verified correctness with a new test case in `report_repository_test.go` that validates weighted distribution of taxable values. Confirmed project-wide build and test passing.

---
*PR created automatically by Jules for task [10075250562083409291](https://jules.google.com/task/10075250562083409291) started by @millennialperfumer-tech*