### PR TITLE
🛡️ Sentinel: [security improvement] Strict webhook verification and secure HMAC comparison

### DIFF
--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -19,7 +19,7 @@ func main() {
 	configsRepo := repository.NewConfigsRepository(db)
 	settingsProvider := config.NewSettingsProvider(configsRepo)
 
-	authService := service.NewAuthService(db, settingsProvider)
+	authService := service.NewAuthService(db, settingsProvider, nil)
 
 	username := os.Getenv("ADMIN_USERNAME")
 	if username == "" {

--- a/backend/internal/automation/whatsapp/handlers.go
+++ b/backend/internal/automation/whatsapp/handlers.go
@@ -136,17 +136,44 @@ func (h *AutomationHandler) SyncTemplateStatus(w http.ResponseWriter, r *http.Re
 }
 
 func (h *AutomationHandler) WhatsAppWebhook(w http.ResponseWriter, r *http.Request) {
-	// 1. Hub Challenge for verification
+	// 1. Hub Challenge for verification (GET request)
 	if r.Method == http.MethodGet {
+		mode := r.URL.Query().Get("hub.mode")
+		token := r.URL.Query().Get("hub.verify_token")
 		challenge := r.URL.Query().Get("hub.challenge")
-		if challenge != "" {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(challenge))
+
+		if mode == "" || token == "" {
+			log.Printf("WhatsApp Webhook: Missing verification parameters")
+			http.Error(w, "Missing verification parameters", http.StatusBadRequest)
 			return
 		}
+
+		if mode != "subscribe" {
+			log.Printf("WhatsApp Webhook: Invalid mode: %s", mode)
+			http.Error(w, "Invalid mode", http.StatusForbidden)
+			return
+		}
+
+		expectedToken := h.settings.GetWhatsAppWebhookVerifyToken()
+		if expectedToken == "" {
+			log.Printf("WhatsApp Webhook ERROR: No whatsapp_webhook_verify_token configured in app_configs")
+			http.Error(w, "Verification not configured", http.StatusInternalServerError)
+			return
+		}
+
+		if token != expectedToken {
+			log.Printf("WhatsApp Webhook: Verify token mismatch") // Security: don't log the token itself
+			http.Error(w, "Invalid verify token", http.StatusForbidden)
+			return
+		}
+
+		log.Printf("WhatsApp Webhook: Verification successful")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(challenge))
+		return
 	}
 
-	// 2. Handle status updates
+	// 2. Handle status updates (POST request)
 	if r.Method == http.MethodPost {
 		// Read body for both validation and unmarshaling
 		body, err := io.ReadAll(r.Body)

--- a/backend/internal/handler/webhook_handler.go
+++ b/backend/internal/handler/webhook_handler.go
@@ -241,8 +241,8 @@ func (h *WebhookHandler) GetWebhookStatus(w http.ResponseWriter, r *http.Request
 func (h *WebhookHandler) verifyWebhook(r *http.Request, body []byte) bool {
 	secret := h.settings.GetShopifyWebhookSecret()
 	if secret == "" {
-		log.Printf("Webhook Warning: No shopify_webhook_secret configured. Skipping validation.")
-		return true
+		log.Printf("Webhook ERROR: No shopify_webhook_secret configured in app_configs. Rejecting request (fail-closed).")
+		return false
 	}
 
 	hmacHeader := r.Header.Get("X-Shopify-Hmac-Sha256")
@@ -255,7 +255,8 @@ func (h *WebhookHandler) verifyWebhook(r *http.Request, body []byte) bool {
 	hash.Write(body)
 	expectedHmac := base64.StdEncoding.EncodeToString(hash.Sum(nil))
 
-	isMatch := hmacHeader == expectedHmac
+	// Security: Use hmac.Equal for constant-time comparison to prevent timing attacks.
+	isMatch := hmac.Equal([]byte(hmacHeader), []byte(expectedHmac))
 	if !isMatch {
 		log.Printf("Webhook HMAC Mismatch!")
 		log.Printf("  Received: %s", hmacHeader)

--- a/backend/internal/service/auth_service_test.go
+++ b/backend/internal/service/auth_service_test.go
@@ -17,9 +17,9 @@ func TestAuthService_Login(t *testing.T) {
 	}
 	defer testutil.CleanupTestDB(db)
 
-	service := NewAuthService(db, nil)
+	service := NewAuthService(db, nil, nil)
 
-	_, err = service.Login("admin@millennialperfumer.in", "admin123")
+	_, _, err = service.Login("admin@millennialperfumer.in", "admin123")
 
 	if err != nil {
 		// We expect an error about nil settings if it tries to GenerateToken
@@ -34,7 +34,7 @@ func TestAuthService_Register(t *testing.T) {
 	}
 	defer testutil.CleanupTestDB(db)
 
-	service := NewAuthService(db, nil)
+	service := NewAuthService(db, nil, nil)
 	err = service.Register("newuser@example.com", "password123")
 	assert.NoError(t, err)
 


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Strict webhook verification and secure HMAC comparison

This PR hardens the security of webhook endpoints by implementing strict verification and fail-closed logic. It also resolves pre-existing build inconsistencies in the codebase.

### 🚨 Severity: MEDIUM (Security Enhancement)

### 💡 Vulnerability
1. **WhatsApp Webhook Bypass**: The GET endpoint for WhatsApp webhook verification returned the challenge regardless of the provided token, allowing unauthorized verification.
2. **Shopify Webhook Fail-Open**: If no Shopify secret was configured, the application defaulted to accepting all webhooks without validation.
3. **HMAC Timing Attack**: Shopify HMACs were compared using standard string equality, which is vulnerable to timing-based side-channel attacks.

### 🎯 Impact
1. Unauthorized actors could trick the system into thinking it was verified by Meta.
2. Environments with missing configurations would process all incoming (potentially malicious) webhooks as legitimate.
3. Minimal risk of HMAC brute-forcing via timing analysis.

### 🔧 Fix
1. **Strict WhatsApp Verification**: Added validation for `hub.mode == "subscribe"` and `hub.verify_token` against the value in `app_configs`.
2. **Fail-Closed Logic**: Modified Shopify `verifyWebhook` to return `false` if the secret is not configured.
3. **Secure Comparison**: Implemented `hmac.Equal` for constant-time HMAC comparison.
4. **Maintenance**: Fixed pre-existing build errors in `cmd/seed/main.go` and `internal/service/auth_service_test.go` where `NewAuthService` calls were missing the required `Messenger` argument.

### ✅ Verification
1. `cd backend && go build ./...` passes.
2. `cd backend && go test ./...` passes.
3. Code review verified that all security patterns align with project standards.

---
*PR created automatically by Jules for task [17527354274363334491](https://jules.google.com/task/17527354274363334491) started by @millennialperfumer-tech*