### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing WhatsApp Webhook verification

### DIFF
--- a/backend/internal/automation/whatsapp/handlers.go
+++ b/backend/internal/automation/whatsapp/handlers.go
@@ -138,10 +138,20 @@ func (h *AutomationHandler) SyncTemplateStatus(w http.ResponseWriter, r *http.Re
 func (h *AutomationHandler) WhatsAppWebhook(w http.ResponseWriter, r *http.Request) {
 	// 1. Hub Challenge for verification
 	if r.Method == http.MethodGet {
+		mode := r.URL.Query().Get("hub.mode")
+		token := r.URL.Query().Get("hub.verify_token")
 		challenge := r.URL.Query().Get("hub.challenge")
-		if challenge != "" {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(challenge))
+
+		if mode != "" && token != "" {
+			expectedToken := h.settings.GetWhatsAppWebhookVerifyToken()
+			if mode == "subscribe" && token == expectedToken {
+				log.Printf("WhatsApp Webhook verified successfully")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(challenge))
+				return
+			}
+			log.Printf("WhatsApp Webhook verification failed: mode=%s, token mismatch", mode)
+			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}
 	}


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Fix missing WhatsApp Webhook verification

#### 🚨 Severity: HIGH
The WhatsApp Webhook verification endpoint (GET) was insecurely echoing back the `hub.challenge` parameter without any validation.

#### 💡 Vulnerability
Meta's WhatsApp Webhook protocol requires a handshake where the server must verify a `hub.verify_token` sent in the GET request against a pre-configured secret. The existing implementation ignored this token and the `hub.mode` parameter, potentially allowing unauthorized parties to register the endpoint.

#### 🎯 Impact
An attacker could potentially verify this API endpoint as a webhook for their own Meta App, leading to misdirection of data or exploitation of the verification mechanism.

#### 🔧 Fix
Updated `WhatsAppWebhook` in `backend/internal/automation/whatsapp/handlers.go` to:
1. Extract `hub.mode`, `hub.verify_token`, and `hub.challenge` from the query parameters.
2. Validate that `hub.mode` is "subscribe".
3. Compare `hub.verify_token` against the secret stored in the system configuration (`SettingsProvider.GetWhatsAppWebhookVerifyToken()`).
4. Only return the challenge if both validations pass.
5. Return `403 Forbidden` if verification fails.

#### ✅ Verification
- Backend tests (`go test ./...`) pass.
- Manual code review confirms the logic matches Meta's required handshake protocol.
- Existing frontend build/lint errors are unrelated to these backend changes.

---
*PR created automatically by Jules for task [10057175807246587487](https://jules.google.com/task/10057175807246587487) started by @millennialperfumer-tech*