### PR TITLE
🎨 Palette: Consistent clear search in WhatsApp Chat

### DIFF
--- a/frontend/src/WhatsAppChat.tsx
+++ b/frontend/src/WhatsAppChat.tsx
@@ -267,10 +267,48 @@ export function WhatsAppChat({ fetchWithAuth }: WhatsAppChatProps) {
               type="text" 
               className="chat-search-input" 
               placeholder="Search chats..." 
+              aria-label="Search chats"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
+              style={{ paddingRight: searchQuery ? '2.5rem' : '1rem' }}
             />
             <svg className="chat-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+            {searchQuery && (
+              <button
+                onClick={() => setSearchQuery('')}
+                aria-label="Clear search"
+                title="Clear search"
+                style={{
+                  position: 'absolute',
+                  right: '12px',
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  color: 'var(--text-tertiary)',
+                  padding: '4px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  borderRadius: '50%',
+                  transition: 'all 0.2s',
+                  cursor: 'pointer',
+                  border: 'none',
+                  background: 'transparent'
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.color = 'var(--text-primary)';
+                  e.currentTarget.style.background = 'var(--bg-hover)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.color = 'var(--text-tertiary)';
+                  e.currentTarget.style.background = 'transparent';
+                }}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18"></line>
+                  <line x1="6" y1="6" x2="18" y2="18"></line>
+                </svg>
+              </button>
+            )}
           </div>
         </div>
         


### PR DESCRIPTION
### 💡 What
Added a "Clear search" button to the WhatsApp Chat sidebar search input.

### 🎯 Why
To improve micro-UX by providing a quick way to reset search filters, ensuring consistency with other modules like Customers and Templates that already follow this pattern.

### 📸 Before/After
- **Before**: The search input in the WhatsApp Chat sidebar lacked a reset mechanism, requiring users to manually delete their query.
- **After**: A responsive "X" icon now appears when text is typed into the search bar. Clicking it immediately clears the search and restores the full list of conversations.

### ♿ Accessibility
- Added `aria-label="Search chats"` to the search input.
- Added `aria-label="Clear search"` and a descriptive `title` to the new button.
- Used a semantic `<button>` element for the clear action to ensure keyboard navigability.

---
*PR created automatically by Jules for task [10723447899181837642](https://jules.google.com/task/10723447899181837642) started by @millennialperfumer-tech*