### PR TITLE
🎨 Palette: Add accessibility labels to icon-only buttons

### DIFF
--- a/frontend/src/ManualWhatsAppModal.tsx
+++ b/frontend/src/ManualWhatsAppModal.tsx
@@ -110,7 +110,7 @@ export const ManualWhatsAppModal: React.FC<ManualWhatsAppModalProps> = ({
       <div className="modal-content" onClick={e => e.stopPropagation()} style={{ maxWidth: '600px', width: '90%' }}>
         <div className="modal-header">
           <h3>Send Webhook Notification</h3>
-          <button className="close-btn" onClick={onClose}>&times;</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close modal">&times;</button>
         </div>
         
         <div className="modal-body">

--- a/frontend/src/Planner.tsx
+++ b/frontend/src/Planner.tsx
@@ -858,7 +858,7 @@ export const Planner: React.FC<PlannerProps> = ({ fetchWithAuth }) => {
                       </h2>
                    </div>
                    {isEditing && (
-                      <button className="delete-btn-lux" onClick={handleDeleteTask}>
+                      <button className="delete-btn-lux" onClick={handleDeleteTask} aria-label="Delete task">
                           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
                       </button>
                    )}
@@ -1015,7 +1015,7 @@ export const Planner: React.FC<PlannerProps> = ({ fetchWithAuth }) => {
                       </div>
                       <h2 style={{ margin: 0, fontWeight: 900, fontSize: '1rem', letterSpacing: '0.05em', textTransform: 'uppercase' }}>{isEditingSprint ? 'Update Sprint' : 'Initialize Sprint'}</h2>
                    </div>
-                   <button className="close-btn-lux" onClick={() => setIsSprintModalOpen(false)}>×</button>
+                   <button className="close-btn-lux" onClick={() => setIsSprintModalOpen(false)} aria-label="Close modal">×</button>
                 </div>
               </div>
 

--- a/frontend/src/PostInsightsModal.tsx
+++ b/frontend/src/PostInsightsModal.tsx
@@ -89,6 +89,7 @@ export const PostInsightsModal: React.FC<PostInsightsModalProps> = ({ post, isOp
       }} onClick={e => e.stopPropagation()}>
         <button 
           onClick={onClose}
+          aria-label="Close insights"
           style={{
             position: 'absolute',
             top: '20px',


### PR DESCRIPTION
### 💡 What
Added `aria-label` attributes to critical icon-only buttons:
- "Close" button in `PostInsightsModal.tsx`
- "Delete Task" and "Close" buttons in `Planner.tsx`
- "Close" button in `ManualWhatsAppModal.tsx`

### 🎯 Why
Icon-only buttons (like those using "×" or SVGs) are not descriptive for screen reader users. Adding `aria-label` makes these actions accessible to all users.

### 📸 Before/After
*Visual UI remains identical, but background accessibility metadata is now present.*

### ♿ Accessibility
Ensured that all destructive (Delete) and navigation (Close) icon-only actions have meaningful text alternatives for assistive technologies.

---
*PR created automatically by Jules for task [8240495039494209793](https://jules.google.com/task/8240495039494209793) started by @millennialperfumer-tech*