### PR TITLE
🛡️ Sentinel: [HIGH] Fix Webhook Integrity for Meta Marketing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `CustomerRepository.List` passed the `sortBy` parameter from user input directly to GORM's `Order()` method without validation.
 **Learning:** ORM methods like GORM's `Order()` often do not parameterize identifiers (like column names) and instead concatenate them into the raw SQL query. This makes them a direct sink for SQL injection if the input is not strictly validated against an allowlist of permitted columns.
 **Prevention:** Always validate dynamic sorting parameters against a hardcoded allowlist map of valid column names before passing them to the database query layer.
+
+## 2026-04-12 - [Webhook Integrity and Timing Attacks in Meta Marketing]
+**Vulnerability:** Meta Marketing Webhook (POST) lacked HMAC signature verification, and the verification token (GET) was compared using standard string equality.
+**Learning:** Webhooks without payload integrity checks (HMAC) are vulnerable to spoofing, and using standard string comparison for tokens can expose them to timing attacks. Webhook handlers also frequently lack body size limits, making them susceptible to DoS attacks.
+**Prevention:** Implement HMAC-SHA256 verification using a secure secret, use `subtle.ConstantTimeCompare` for token validation, and enforce request body size limits with `http.MaxBytesReader`.

--- a/backend/internal/handler/marketing_webhook_handler.go
+++ b/backend/internal/handler/marketing_webhook_handler.go
@@ -1,10 +1,16 @@
 package handler
 
 import (
-	"fmt"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"io"
+	"log"
 	"mi-tech/internal/config"
 	"mi-tech/internal/marketing"
 	"net/http"
+	"strings"
 )
 
 type MarketingWebhookHandler struct {
@@ -43,20 +49,54 @@ func (h *MarketingWebhookHandler) verifyWebhook(w http.ResponseWriter, r *http.R
 
 	expectedToken := h.settings.GetMetaMarketingWebhookVerifyToken()
 
-	if mode == "subscribe" && token == expectedToken {
-		fmt.Printf("Meta Marketing Webhook verified successfully!\n")
+	// Use ConstantTimeCompare to prevent timing attacks
+	if mode == "subscribe" && subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1 {
+		log.Printf("Meta Marketing Webhook verified successfully!\n")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(challenge))
 		return
 	}
 
+	log.Printf("Meta Marketing Webhook verification failed\n")
 	http.Error(w, "Verification failed", http.StatusForbidden)
 }
 
 func (h *MarketingWebhookHandler) handleNotification(w http.ResponseWriter, r *http.Request) {
+	// Security: Enforce a 1MB limit for the request body to prevent DoS.
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("Error reading Meta Marketing Webhook body: %v", err)
+		http.Error(w, "Payload too large or unreadable", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	// Security: Verify X-Hub-Signature-256 to ensure payload integrity.
+	signature := r.Header.Get("X-Hub-Signature-256")
+	if !h.validateSignature(body, signature) {
+		log.Printf("Invalid Meta Marketing Webhook signature")
+		http.Error(w, "Invalid signature", http.StatusUnauthorized)
+		return
+	}
+
 	// For now, we just acknowledge and log.
 	// In a real implementation, we'd parse the 'ads_management' or 'ads_insights' payload.
-	fmt.Printf("Received Meta Marketing Notification\n")
+	log.Printf("Received Valid Meta Marketing Notification\n")
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("Acknowledged"))
+}
+
+func (h *MarketingWebhookHandler) validateSignature(body []byte, signature string) bool {
+	if signature == "" || !strings.HasPrefix(signature, "sha256=") {
+		return false
+	}
+
+	actualHash := signature[7:]
+	secret := h.settings.GetMetaAppSecret()
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	expectedHash := hex.EncodeToString(mac.Sum(nil))
+
+	return hmac.Equal([]byte(actualHash), []byte(expectedHash))
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The Meta Marketing Webhook handler previously accepted POST notifications without verifying their HMAC signatures and performed GET verification using standard string comparison. It also lacked a request body size limit.
🎯 Impact: This allowed for potential spoofing of marketing events, timing attacks to brute-force the verification token, and resource exhaustion via large payloads.
🔧 Fix:
- Added HMAC-SHA256 verification using the `X-Hub-Signature-256` header.
- Implemented `subtle.ConstantTimeCompare` for secure token validation.
- Enforced a 1MB limit on request bodies using `http.MaxBytesReader`.
✅ Verification: Code reviewed and verified; `internal/handler` test suite passed.

---
*PR created automatically by Jules for task [15389726168438787215](https://jules.google.com/task/15389726168438787215) started by @millennialperfumer-tech*