### PR TITLE
🎨 Palette: Standardize accessibility for icon-only buttons

### DIFF
--- a/frontend/src/ManualWhatsAppModal.tsx
+++ b/frontend/src/ManualWhatsAppModal.tsx
@@ -110,7 +110,7 @@ export const ManualWhatsAppModal: React.FC<ManualWhatsAppModalProps> = ({
       <div className="modal-content" onClick={e => e.stopPropagation()} style={{ maxWidth: '600px', width: '90%' }}>
         <div className="modal-header">
           <h3>Send Webhook Notification</h3>
-          <button className="close-btn" onClick={onClose}>&times;</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close" title="Close">&times;</button>
         </div>
         
         <div className="modal-body">

--- a/frontend/src/Planner.tsx
+++ b/frontend/src/Planner.tsx
@@ -609,7 +609,7 @@ export const Planner: React.FC<PlannerProps> = ({ fetchWithAuth }) => {
         </div>
         
         <div style={{ display: 'flex', gap: '0.75rem' }}>
-          <button className="btn-secondary" style={{ padding: '0.6rem 1rem' }} onClick={loadAllData}>
+          <button className="btn-secondary" style={{ padding: '0.6rem 1rem' }} onClick={loadAllData} aria-label="Refresh data" title="Refresh data">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
           </button>
           <button 
@@ -858,7 +858,7 @@ export const Planner: React.FC<PlannerProps> = ({ fetchWithAuth }) => {
                       </h2>
                    </div>
                    {isEditing && (
-                      <button className="delete-btn-lux" onClick={handleDeleteTask}>
+                      <button className="delete-btn-lux" onClick={handleDeleteTask} aria-label="Delete task" title="Delete task">
                           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
                       </button>
                    )}
@@ -906,7 +906,7 @@ export const Planner: React.FC<PlannerProps> = ({ fetchWithAuth }) => {
                                         </div>
                                     </div>
                                     <span className="subtask-label-lux">{sub.title}</span>
-                                    <button className="subtask-remove-lux" onClick={() => deleteSubtask(sub.id)}>
+                                    <button className="subtask-remove-lux" onClick={() => deleteSubtask(sub.id)} aria-label="Remove subtask" title="Remove subtask">
                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
                                     </button>
                                 </div>
@@ -1015,7 +1015,7 @@ export const Planner: React.FC<PlannerProps> = ({ fetchWithAuth }) => {
                       </div>
                       <h2 style={{ margin: 0, fontWeight: 900, fontSize: '1rem', letterSpacing: '0.05em', textTransform: 'uppercase' }}>{isEditingSprint ? 'Update Sprint' : 'Initialize Sprint'}</h2>
                    </div>
-                   <button className="close-btn-lux" onClick={() => setIsSprintModalOpen(false)}>×</button>
+                   <button className="close-btn-lux" onClick={() => setIsSprintModalOpen(false)} aria-label="Close" title="Close">×</button>
                 </div>
               </div>
 

--- a/frontend/src/PostInsightsModal.tsx
+++ b/frontend/src/PostInsightsModal.tsx
@@ -89,6 +89,8 @@ export const PostInsightsModal: React.FC<PostInsightsModalProps> = ({ post, isOp
       }} onClick={e => e.stopPropagation()}>
         <button 
           onClick={onClose}
+          aria-label="Close"
+          title="Close"
           style={{
             position: 'absolute',
             top: '20px',

--- a/frontend/src/Tickets.tsx
+++ b/frontend/src/Tickets.tsx
@@ -224,7 +224,7 @@ export const Tickets: React.FC<TicketsProps> = ({ fetchWithAuth }) => {
           <div className="modal-content glass-island-premium" onClick={e => e.stopPropagation()} style={{ maxWidth: '500px' }}>
             <div className="modal-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
               <h2 style={{ fontSize: '1.25rem', fontWeight: 700, color: 'var(--text-primary)', margin: 0 }}>Raise New Ticket</h2>
-              <button className="btn-icon-minimal" aria-label="Close modal" onClick={() => setIsModalOpen(false)} style={{ border: 'none', background: 'none', cursor: 'pointer', fontSize: '1.2rem', color: 'var(--text-secondary)' }}>✕</button>
+              <button className="btn-icon-minimal" aria-label="Close modal" title="Close modal" onClick={() => setIsModalOpen(false)} style={{ border: 'none', background: 'none', cursor: 'pointer', fontSize: '1.2rem', color: 'var(--text-secondary)' }}>✕</button>
             </div>
             
             <div className="modal-body" style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem', padding: '1.5rem 0' }}>


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to icon-only buttons (close, refresh, delete) across four key frontend components.

🎯 Why: To improve accessibility for screen reader users and provide intuitive tooltips for mouse users, addressing a specific gap in the current UI design system.

📸 Before/After: 
- Before: Icon buttons had no textual description for accessibility tools.
- After: Buttons like '×' now explicitly identify as "Close" or "Close modal".

♿ Accessibility: Implemented recommended ARIA standards for icon-only interactive elements.

---
*PR created automatically by Jules for task [4136645502879554225](https://jules.google.com/task/4136645502879554225) started by @millennialperfumer-tech*