### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix authentication bypass in WhatsApp Webhook

### DIFF
--- a/backend/internal/automation/whatsapp/handlers.go
+++ b/backend/internal/automation/whatsapp/handlers.go
@@ -3,6 +3,7 @@ package whatsapp
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -175,17 +176,29 @@ func (h *AutomationHandler) SyncTemplateStatus(w http.ResponseWriter, r *http.Re
 // @Success 200 {string} string "OK"
 // @Router /automation/whatsapp/webhook [post]
 func (h *AutomationHandler) WhatsAppWebhook(w http.ResponseWriter, r *http.Request) {
-	// 1. Hub Challenge for verification
+	// 1. Hub Challenge for verification (GET)
 	if r.Method == http.MethodGet {
-		challenge := r.URL.Query().Get("hub.challenge")
-		if challenge != "" {
+		query := r.URL.Query()
+		mode := query.Get("hub.mode")
+		token := query.Get("hub.verify_token")
+		challenge := query.Get("hub.challenge")
+
+		expectedToken := h.settings.GetWhatsAppWebhookVerifyToken()
+
+		// Secure comparison using ConstantTimeCompare to prevent timing attacks
+		if mode == "subscribe" && subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1 {
+			log.Printf("WhatsApp Webhook verified successfully!")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(challenge))
 			return
 		}
+
+		log.Printf("WhatsApp Webhook verification failed: mode=%s, token_match=%v", mode, token == expectedToken)
+		http.Error(w, "Verification failed", http.StatusForbidden)
+		return
 	}
 
-	// 2. Handle status updates
+	// 2. Handle data notifications (POST)
 	if r.Method == http.MethodPost {
 		// Read body for both validation and unmarshaling
 		body, err := io.ReadAll(r.Body)

--- a/backend/internal/handler/marketing_webhook_handler.go
+++ b/backend/internal/handler/marketing_webhook_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"mi-tech/internal/config"
 	"mi-tech/internal/marketing"
@@ -43,7 +44,7 @@ func (h *MarketingWebhookHandler) verifyWebhook(w http.ResponseWriter, r *http.R
 
 	expectedToken := h.settings.GetMetaMarketingWebhookVerifyToken()
 
-	if mode == "subscribe" && token == expectedToken {
+	if mode == "subscribe" && subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1 {
 		fmt.Printf("Meta Marketing Webhook verified successfully!\n")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(challenge))


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The WhatsApp Webhook GET handler was echoing back the `hub.challenge` without verifying the `hub.verify_token`. This allowed anyone to verify the webhook endpoint in their own Meta developer account. Additionally, standard string comparisons were used for tokens, which are vulnerable to timing attacks.
🎯 Impact: Unauthorized entities could verify the webhook, potentially leading to webhook hijacking or misconfiguration. Timing attacks could allow attackers to guess verification tokens.
🔧 Fix:
- Implemented strict validation for `hub.mode == "subscribe"` and `hub.verify_token` in `WhatsAppWebhook`.
- Replaced string comparisons with `subtle.ConstantTimeCompare` in both WhatsApp and Meta Marketing webhook handlers.
- Added appropriate logging for verification failures.
✅ Verification:
- Manual code review confirmed the logic follows Meta's security requirements.
- Backend tests in `internal/automation/whatsapp` and `internal/handler` pass.
- `go build ./...` succeeds.

---
*PR created automatically by Jules for task [9032230104463084396](https://jules.google.com/task/9032230104463084396) started by @millennialperfumer-tech*