### PR TITLE
⚡ Bolt: Batch inventory deduction in OrderRepository.UpsertBatch

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2026-03-27 - [Optimizing Reporting with SQL Aggregations and Window Functions]
 **Learning:** Combining multiple metrics into a single SQL query using `FILTER` and `CASE` (conditional aggregation) eliminates redundant database roundtrips and application-side processing. For HSN/line-item reports, replacing global CTE scans with window functions (`SUM(...) OVER (PARTITION BY order_id)`) within date-filtered JOINs ensures the database only processes relevant rows, significantly improving performance as the table grows.
 **Action:** Always prefer conditional SQL aggregation over multiple repository calls for dashboard/reporting logic. Use window functions for per-group aggregations within filtered result sets to avoid full table scans.
+
+## 2026-03-27 - [Batch Inventory Deduction]
+**Learning:** Sequential inventory deduction during batch order upserts creates an O(N*M) bottleneck (N orders, M items). By aggregating all SKUs in the batch, fetching mappings once, and summing quantities per internal item, database roundtrips are reduced to O(1) for mappings and O(Unique Items) for updates.
+**Action:** When processing batches of entities that trigger side effects (like inventory updates), always aggregate the side effects and perform them in bulk after the primary batch operation.

--- a/backend/internal/repository/order_repository.go
+++ b/backend/internal/repository/order_repository.go
@@ -184,6 +184,92 @@ func (r *gormOrderRepository) deductInventory(tx *gorm.DB, order *entity.Order) 
 	return nil
 }
 
+// deductInventoryBatch performs inventory deduction for a batch of orders.
+// Optimization: Reduces database roundtrips by fetching all SKU mappings in one query
+// and aggregating stock updates per InventoryItem.
+func (r *gormOrderRepository) deductInventoryBatch(tx *gorm.DB, orders []entity.Order) error {
+	var ordersToProcess []*entity.Order
+	skuMap := make(map[string]map[string]bool) // platform -> external_sku -> true
+
+	for i := range orders {
+		if orders[i].InventoryDeducted {
+			continue
+		}
+		ordersToProcess = append(ordersToProcess, &orders[i])
+		if skuMap[orders[i].SourceID] == nil {
+			skuMap[orders[i].SourceID] = make(map[string]bool)
+		}
+		for _, li := range orders[i].LineItems {
+			if li.SKU != nil && *li.SKU != "" {
+				skuMap[orders[i].SourceID][*li.SKU] = true
+			}
+		}
+	}
+
+	if len(ordersToProcess) == 0 {
+		return nil
+	}
+
+	// Fetch mappings in batch
+	var allMappings []entity.InventoryMapping
+	for platform, skus := range skuMap {
+		var platformSkus []string
+		for sku := range skus {
+			platformSkus = append(platformSkus, sku)
+		}
+		var mappings []entity.InventoryMapping
+		if err := tx.Where("platform = ? AND external_sku IN ?", platform, platformSkus).Find(&mappings).Error; err != nil {
+			return fmt.Errorf("failed to fetch mappings for %s: %w", platform, err)
+		}
+		allMappings = append(allMappings, mappings...)
+	}
+
+	// Create a lookup map: platform:external_sku -> InventoryItemID
+	mappingLookup := make(map[string]int)
+	for _, m := range allMappings {
+		key := fmt.Sprintf("%s:%s", m.Platform, m.ExternalSKU)
+		mappingLookup[key] = m.InventoryItemID
+	}
+
+	// Aggregate deductions
+	deductions := make(map[int]int) // InventoryItemID -> total quantity to deduct
+	for _, o := range ordersToProcess {
+		for _, li := range o.LineItems {
+			if li.SKU == nil || *li.SKU == "" {
+				continue
+			}
+			key := fmt.Sprintf("%s:%s", o.SourceID, *li.SKU)
+			if itemID, ok := mappingLookup[key]; ok {
+				deductions[itemID] += li.Quantity
+			}
+		}
+	}
+
+	// Apply deductions
+	for itemID, qty := range deductions {
+		if err := tx.Model(&entity.InventoryItem{}).
+			Where("id = ?", itemID).
+			Update("current_stock", gorm.Expr("current_stock - ?", qty)).Error; err != nil {
+			return fmt.Errorf("failed to deduct stock for item %d: %w", itemID, err)
+		}
+	}
+
+	// Mark all as deducted
+	var orderIDs []int64
+	for _, o := range ordersToProcess {
+		o.InventoryDeducted = true
+		orderIDs = append(orderIDs, o.ID)
+	}
+
+	if len(orderIDs) > 0 {
+		if err := tx.Model(&entity.Order{}).Where("id IN ?", orderIDs).Update("inventory_deducted", true).Error; err != nil {
+			return fmt.Errorf("failed to update inventory_deducted flag: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func (r *gormOrderRepository) Upsert(order entity.Order) error {
 	if order.CustomerPhone != nil {
 		normalized := entity.NormalizePhone(*order.CustomerPhone)
@@ -390,18 +476,11 @@ func (r *gormOrderRepository) UpsertBatch(orders []entity.Order) error {
 			}
 		}
 
-		// 4. Deduct Inventory for all orders in batch
-		for i := range orders {
-			if err := r.deductInventory(tx, &orders[i]); err != nil {
-				return err
-			}
-			// Update individual order flag
-			if err := tx.Model(&orders[i]).Update("inventory_deducted", orders[i].InventoryDeducted).Error; err != nil {
-				return err
-			}
+		// 4. Deduct Inventory for all orders in batch (Optimized)
+		if err := r.deductInventoryBatch(tx, orders); err != nil {
+			return err
 		}
 
-		return nil
 		return nil
 	})
 }


### PR DESCRIPTION
💡 What: Implemented a new `deductInventoryBatch` method in `gormOrderRepository` and refactored `UpsertBatch` to use it.
🎯 Why: The previous implementation of `UpsertBatch` called `deductInventory` iteratively for each order, creating an N+1 query problem where database roundtrips scaled with the number of orders and line items.
📊 Impact: Reduces database roundtrips from O(N*M) to O(1) for mapping lookups and O(Unique Items) for stock updates. For a batch of 250 orders, this can reduce hundreds of queries to just a few.
🔬 Measurement: Verified via manual code review and successful backend compilation (`go build`).

---
*PR created automatically by Jules for task [6734031777214931282](https://jules.google.com/task/6734031777214931282) started by @millennialperfumer-tech*