### PR TITLE
🛡️ Sentinel: [HIGH] Fix Webhook Authentication Bypass and Timing Attacks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `CustomerRepository.List` passed the `sortBy` parameter from user input directly to GORM's `Order()` method without validation.
 **Learning:** ORM methods like GORM's `Order()` often do not parameterize identifiers (like column names) and instead concatenate them into the raw SQL query. This makes them a direct sink for SQL injection if the input is not strictly validated against an allowlist of permitted columns.
 **Prevention:** Always validate dynamic sorting parameters against a hardcoded allowlist map of valid column names before passing them to the database query layer.
+
+## 2026-04-19 - [Unverified Webhook Challenges and Timing Attacks]
+**Vulnerability:** Meta (WhatsApp/Marketing) webhook verification endpoints were returning the `hub.challenge` without verifying the `hub.verify_token`, and signature checks were susceptible to timing attacks.
+**Learning:** Webhook verification often involves a GET request for a challenge-response handshake. Failing to verify the secret token during this handshake allows unauthorized parties to "verify" their own endpoints as if they were the application. Furthermore, using standard string comparison for signatures allows attackers to measure response times and brute-force the secret.
+**Prevention:** Always verify the handshake token during webhook setup using constant-time comparison (`subtle.ConstantTimeCompare`). For notifications (POST), always verify the HMAC signature using the platform's app secret and constant-time comparison.

--- a/backend/internal/automation/whatsapp/handlers.go
+++ b/backend/internal/automation/whatsapp/handlers.go
@@ -3,6 +3,7 @@ package whatsapp
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -175,14 +176,31 @@ func (h *AutomationHandler) SyncTemplateStatus(w http.ResponseWriter, r *http.Re
 // @Success 200 {string} string "OK"
 // @Router /automation/whatsapp/webhook [post]
 func (h *AutomationHandler) WhatsAppWebhook(w http.ResponseWriter, r *http.Request) {
-	// 1. Hub Challenge for verification
+	// 1. Hub Challenge for verification (GET)
 	if r.Method == http.MethodGet {
-		challenge := r.URL.Query().Get("hub.challenge")
-		if challenge != "" {
+		query := r.URL.Query()
+		mode := query.Get("hub.mode")
+		token := query.Get("hub.verify_token")
+		challenge := query.Get("hub.challenge")
+
+		expectedToken := h.settings.GetWhatsAppWebhookVerifyToken()
+		if expectedToken == "" {
+			log.Printf("WhatsApp Webhook Error: No whatsapp_webhook_verify_token configured")
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+
+		// Security: Use constant-time comparison to prevent timing attacks
+		if mode == "subscribe" && subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1 {
+			log.Printf("WhatsApp Webhook verified successfully")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(challenge))
 			return
 		}
+
+		log.Printf("WhatsApp Webhook verification failed")
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
 	}
 
 	// 2. Handle status updates

--- a/backend/internal/handler/marketing_webhook_handler.go
+++ b/backend/internal/handler/marketing_webhook_handler.go
@@ -1,10 +1,16 @@
 package handler
 
 import (
-	"fmt"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"io"
+	"log"
 	"mi-tech/internal/config"
 	"mi-tech/internal/marketing"
 	"net/http"
+	"strings"
 )
 
 type MarketingWebhookHandler struct {
@@ -42,21 +48,69 @@ func (h *MarketingWebhookHandler) verifyWebhook(w http.ResponseWriter, r *http.R
 	challenge := query.Get("hub.challenge")
 
 	expectedToken := h.settings.GetMetaMarketingWebhookVerifyToken()
+	if expectedToken == "" {
+		log.Printf("Meta Marketing Webhook Error: No meta_marketing_webhook_verify_token configured")
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 
-	if mode == "subscribe" && token == expectedToken {
-		fmt.Printf("Meta Marketing Webhook verified successfully!\n")
+	// Security: Use constant-time comparison to prevent timing attacks
+	if mode == "subscribe" && subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1 {
+		log.Printf("Meta Marketing Webhook verified successfully!")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(challenge))
 		return
 	}
 
+	log.Printf("Meta Marketing Webhook verification failed")
 	http.Error(w, "Verification failed", http.StatusForbidden)
 }
 
 func (h *MarketingWebhookHandler) handleNotification(w http.ResponseWriter, r *http.Request) {
-	// For now, we just acknowledge and log.
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("Meta Marketing Webhook Error: Failed to read body: %v", err)
+		http.Error(w, "Failed to read body", http.StatusInternalServerError)
+		return
+	}
+	defer r.Body.Close()
+
+	// 1. Security: Validate X-Hub-Signature-256
+	signature := r.Header.Get("X-Hub-Signature-256")
+	if !h.validateMetaSignature(body, signature) {
+		log.Printf("Meta Marketing Webhook Error: Invalid signature")
+		http.Error(w, "Invalid signature", http.StatusUnauthorized)
+		return
+	}
+
+	log.Printf("Received Meta Marketing Notification: %s", string(body))
+
+	// For now, we just acknowledge.
 	// In a real implementation, we'd parse the 'ads_management' or 'ads_insights' payload.
-	fmt.Printf("Received Meta Marketing Notification\n")
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("Acknowledged"))
+}
+
+func (h *MarketingWebhookHandler) validateMetaSignature(body []byte, signature string) bool {
+	if signature == "" {
+		return false
+	}
+
+	// Signature format: sha256=HEX_DIGEST
+	if !strings.HasPrefix(signature, "sha256=") {
+		return false
+	}
+	actualHash := signature[7:]
+
+	appSecret := h.settings.GetMetaAppSecret()
+	if appSecret == "" {
+		log.Printf("Meta Marketing Webhook Warning: No meta_app_secret configured for validation")
+		return false // Fail-closed
+	}
+
+	mac := hmac.New(sha256.New, []byte(appSecret))
+	mac.Write(body)
+	expectedHash := hex.EncodeToString(mac.Sum(nil))
+
+	return subtle.ConstantTimeCompare([]byte(actualHash), []byte(expectedHash)) == 1
 }


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: 
1. WhatsApp and Meta Marketing webhooks were returning `hub.challenge` tokens during the GET handshake without actually verifying the `hub.verify_token`.
2. Existing webhook verification and signature checks were susceptible to timing attacks due to standard string comparison.
3. Meta Marketing notifications (POST) lacked HMAC-SHA256 integrity and authenticity verification.

🎯 Impact: 
Attackers could unauthorizedly "verify" webhook endpoints they controlled, or potentially spoof/tamper with marketing notification data. Timing side-channels could be used to brute-force verification tokens or app secrets.

🔧 Fix: 
- Implemented mandatory `hub.mode == "subscribe"` and `hub.verify_token` validation in both WhatsApp and Meta Marketing GET handlers.
- Switched all secret-based comparisons to use `crypto/subtle.ConstantTimeCompare`.
- Implemented full HMAC-SHA256 signature verification for Meta Marketing POST notifications using the `X-Hub-Signature-256` header and the Meta App Secret.
- Implemented fail-closed logic where verification fails if the required secrets are not configured in the system.

✅ Verification: 
- Verified backend build success (`cd backend && go build cmd/main.go`).
- Verified system integrity with existing test suite (`cd backend && go test ./...`).
- Manual code review confirms implementation of constant-time comparison and proper fail-closed paths.

---
*PR created automatically by Jules for task [2811039722587697438](https://jules.google.com/task/2811039722587697438) started by @millennialperfumer-tech*