### PR TITLE
⚡ Bolt: Optimize inventory deduction in UpsertBatch

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2026-03-27 - [Optimizing Reporting with SQL Aggregations and Window Functions]
 **Learning:** Combining multiple metrics into a single SQL query using `FILTER` and `CASE` (conditional aggregation) eliminates redundant database roundtrips and application-side processing. For HSN/line-item reports, replacing global CTE scans with window functions (`SUM(...) OVER (PARTITION BY order_id)`) within date-filtered JOINs ensures the database only processes relevant rows, significantly improving performance as the table grows.
 **Action:** Always prefer conditional SQL aggregation over multiple repository calls for dashboard/reporting logic. Use window functions for per-group aggregations within filtered result sets to avoid full table scans.
+
+## 2026-04-21 - [Consolidating N+1 Inventory Deductions]
+**Learning:** Sequential inventory deduction in batch order processing creates an $O(N \times M)$ database round-trip bottleneck. Konsolidating SKU mapping lookups into a single tuple `IN` query (`WHERE (platform, sku) IN ?`) and aggregating stock updates in-memory reduces round-trips to $O(1 + K)$, where $K$ is the number of unique inventory items.
+**Action:** Always look for patterns where child entity lookups or updates can be grouped using tuple `IN` clauses or bulk updates to minimize the impact of network latency and query overhead in GORM.

--- a/backend/internal/repository/order_repository.go
+++ b/backend/internal/repository/order_repository.go
@@ -155,32 +155,76 @@ func (r *gormOrderRepository) mergePII(existing *entity.Order, incoming *entity.
 	}
 }
 
-func (r *gormOrderRepository) deductInventory(tx *gorm.DB, order *entity.Order) error {
-	if order.InventoryDeducted {
+func (r *gormOrderRepository) deductInventoryBatch(tx *gorm.DB, orders []*entity.Order) error {
+	type skuKey struct {
+		Platform string
+		SKU      string
+	}
+
+	uniqueKeys := make(map[skuKey]bool)
+	ordersToProcess := make([]*entity.Order, 0)
+
+	for _, o := range orders {
+		if o.InventoryDeducted {
+			continue
+		}
+		ordersToProcess = append(ordersToProcess, o)
+		for _, li := range o.LineItems {
+			if li.SKU != nil && *li.SKU != "" {
+				uniqueKeys[skuKey{Platform: o.SourceID, SKU: *li.SKU}] = true
+			}
+		}
+	}
+
+	if len(ordersToProcess) == 0 {
 		return nil
 	}
 
-	for _, li := range order.LineItems {
-		if li.SKU == nil || *li.SKU == "" {
-			continue
+	if len(uniqueKeys) > 0 {
+		// Build the tuple IN query for all platform-sku pairs
+		var mappings []entity.InventoryMapping
+		pairs := make([][]interface{}, 0, len(uniqueKeys))
+		for k := range uniqueKeys {
+			pairs = append(pairs, []interface{}{k.Platform, k.SKU})
 		}
 
-		var mapping entity.InventoryMapping
-		err := tx.Where("platform = ? AND external_sku = ?", order.SourceID, *li.SKU).First(&mapping).Error
-		if err != nil {
-			// No mapping for this SKU, skip
-			continue
+		// Batch fetch all relevant mappings
+		if err := tx.Where("(platform, external_sku) IN ?", pairs).Find(&mappings).Error; err != nil {
+			return fmt.Errorf("failed to fetch inventory mappings in batch: %w", err)
 		}
 
-		// Deduct stock
-		if err := tx.Model(&entity.InventoryItem{}).
-			Where("id = ?", mapping.InventoryItemID).
-			Update("current_stock", gorm.Expr("current_stock - ?", li.Quantity)).Error; err != nil {
-			return fmt.Errorf("failed to deduct stock for %s: %w", *li.SKU, err)
+		mappingMap := make(map[skuKey]int)
+		for _, m := range mappings {
+			mappingMap[skuKey{Platform: m.Platform, SKU: m.ExternalSKU}] = m.InventoryItemID
+		}
+
+		// Aggregate deductions by InventoryItemID
+		deductions := make(map[int]int)
+		for _, o := range ordersToProcess {
+			for _, li := range o.LineItems {
+				if li.SKU == nil || *li.SKU == "" {
+					continue
+				}
+				if itemID, found := mappingMap[skuKey{Platform: o.SourceID, SKU: *li.SKU}]; found {
+					deductions[itemID] += li.Quantity
+				}
+			}
+		}
+
+		// Perform one update per unique inventory item affected
+		for itemID, qty := range deductions {
+			if err := tx.Model(&entity.InventoryItem{}).
+				Where("id = ?", itemID).
+				Update("current_stock", gorm.Expr("current_stock - ?", qty)).Error; err != nil {
+				return fmt.Errorf("failed to deduct stock for inventory item %d: %w", itemID, err)
+			}
 		}
 	}
 
-	order.InventoryDeducted = true
+	for _, o := range ordersToProcess {
+		o.InventoryDeducted = true
+	}
+
 	return nil
 }
 
@@ -274,14 +318,12 @@ func (r *gormOrderRepository) Upsert(order entity.Order) error {
 		}
 
 		// 4. Deduct Inventory
-		if err := r.deductInventory(tx, &order); err != nil {
+		if err := r.deductInventoryBatch(tx, []*entity.Order{&order}); err != nil {
 			return err
 		}
 
 		// Update order again with inventory_deducted flag
 		return tx.Model(&order).Update("inventory_deducted", order.InventoryDeducted).Error
-
-		return nil
 	})
 }
 
@@ -391,17 +433,29 @@ func (r *gormOrderRepository) UpsertBatch(orders []entity.Order) error {
 		}
 
 		// 4. Deduct Inventory for all orders in batch
+		orderPtrs := make([]*entity.Order, len(orders))
+		orderIDs := make([]int64, 0, len(orders))
 		for i := range orders {
-			if err := r.deductInventory(tx, &orders[i]); err != nil {
-				return err
-			}
-			// Update individual order flag
-			if err := tx.Model(&orders[i]).Update("inventory_deducted", orders[i].InventoryDeducted).Error; err != nil {
-				return err
+			orderPtrs[i] = &orders[i]
+		}
+
+		if err := r.deductInventoryBatch(tx, orderPtrs); err != nil {
+			return err
+		}
+
+		// Update order flags in one batch
+		for i := range orders {
+			if orders[i].InventoryDeducted {
+				orderIDs = append(orderIDs, orders[i].ID)
 			}
 		}
 
-		return nil
+		if len(orderIDs) > 0 {
+			if err := tx.Model(&entity.Order{}).Where("id IN ?", orderIDs).Update("inventory_deducted", true).Error; err != nil {
+				return fmt.Errorf("failed to batch update inventory_deducted flag: %w", err)
+			}
+		}
+
 		return nil
 	})
 }


### PR DESCRIPTION
### 💡 What
Optimized the inventory deduction logic in `OrderRepository` by refactoring the sequential per-line-item processing into a batch-aware operation.

### 🎯 Why
The previous implementation performed multiple database queries (`SELECT` for mapping and `UPDATE` for stock) for *every* line item of *every* order in a batch. For a batch of 50 orders with 2 line items each, this resulted in 100+ database round-trips, creating a significant performance bottleneck during bulk sync operations.

### 📊 Impact
Reduces database round-trips from $O(N \times M)$ to $O(1 + K)$, where $N$ is the number of orders, $M$ is line items, and $K$ is unique inventory items affected. In typical scenarios, this will reduce the number of queries for a batch of 50 orders from ~100+ down to ~5-10, significantly improving sync speed and reducing database load.

### 🔬 Measurement
The optimization was verified through:
- **Theoretical Analysis:** Quantified the reduction in DB round-trips based on the algorithm change.
- **Static Analysis & Manual Review:** Verified that the batched logic correctly handles SKU mappings and aggregates quantities.
- **Compilation Check:** Verified that the backend builds successfully with `go build ./...`.
- **Existing Tests:** Verified that the codebase remains functional by running existing repository tests.

---
*PR created automatically by Jules for task [13860253641802985240](https://jules.google.com/task/13860253641802985240) started by @millennialperfumer-tech*