### PR TITLE
⚡ Bolt: Pre-compile regular expressions and allowlist maps

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2026-03-27 - [Optimizing Reporting with SQL Aggregations and Window Functions]
 **Learning:** Combining multiple metrics into a single SQL query using `FILTER` and `CASE` (conditional aggregation) eliminates redundant database roundtrips and application-side processing. For HSN/line-item reports, replacing global CTE scans with window functions (`SUM(...) OVER (PARTITION BY order_id)`) within date-filtered JOINs ensures the database only processes relevant rows, significantly improving performance as the table grows.
 **Action:** Always prefer conditional SQL aggregation over multiple repository calls for dashboard/reporting logic. Use window functions for per-group aggregations within filtered result sets to avoid full table scans.
+
+## 2026-04-26 - [Regex Pre-compilation and Static Map Allocation]
+**Learning:** Repeatedly calling `regexp.MustCompile` and re-allocating allowlist maps within high-traffic functions (like search parsing and list filtering) introduces significant CPU and memory overhead. Pre-compiling these into package-level variables ensures O(1) initialization and reduces GC pressure.
+**Action:** Always define descriptive package-level variables for regular expressions and static lookup maps used in frequently called service or repository methods.

--- a/backend/internal/automation/whatsapp/webhook_mapping_service.go
+++ b/backend/internal/automation/whatsapp/webhook_mapping_service.go
@@ -16,7 +16,10 @@ import (
 	"time"
 )
 
-var phoneRegex = regexp.MustCompile(`[^0-9]`)
+var (
+	phoneRegex         = regexp.MustCompile(`[^0-9]`)
+	templateParamRegex = regexp.MustCompile(`\{\{(\d+)\}\}`)
+)
 
 func sanitizePhoneNumber(phone string) string {
 	if phone == "555-555-SHIP" {
@@ -427,8 +430,7 @@ func (s *WebhookMappingService) executeWithTemplate(storeID string, template *Au
 
 // countRequiredParams finds the maximum {{n}} placeholder in the template body.
 func (s *WebhookMappingService) countRequiredParams(body string) int {
-	re := regexp.MustCompile(`\{\{(\d+)\}\}`)
-	matches := re.FindAllStringSubmatch(body, -1)
+	matches := templateParamRegex.FindAllStringSubmatch(body, -1)
 	max := 0
 	for _, m := range matches {
 		if len(m) > 1 {

--- a/backend/internal/repository/customer_repository.go
+++ b/backend/internal/repository/customer_repository.go
@@ -9,6 +9,12 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+var customerListAllowedSortColumns = map[string]bool{
+	"phone_number": true, "first_name": true, "last_name": true,
+	"email": true, "city": true, "state": true, "total_orders": true,
+	"total_spent": true, "updated_at": true, "created_at": true,
+}
+
 type CustomerRepository struct {
 	db *gorm.DB
 }
@@ -162,13 +168,7 @@ func (r *CustomerRepository) List(ctx context.Context, search, sortBy, sortOrder
 	}
 
 	// Security: Use allowlist for sortBy to prevent SQL injection.
-	allowedSortColumns := map[string]bool{
-		"phone_number": true, "first_name": true, "last_name": true,
-		"email": true, "city": true, "state": true, "total_orders": true,
-		"total_spent": true, "updated_at": true, "created_at": true,
-	}
-
-	if sortBy != "" && allowedSortColumns[sortBy] {
+	if sortBy != "" && customerListAllowedSortColumns[sortBy] {
 		order := sortBy
 		if sortOrder == "ASC" || sortOrder == "DESC" {
 			order += " " + sortOrder

--- a/backend/internal/repository/order_repository.go
+++ b/backend/internal/repository/order_repository.go
@@ -14,6 +14,12 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+var orderListAllowedSortColumns = map[string]bool{
+	"created_at": true, "order_number": true, "total_price": true,
+	"customer_name": true, "source_id": true, "financial_status": true,
+	"fulfillment_status": true,
+}
+
 // gormOrderRepository is the GORM implementation of OrderRepository.
 type gormOrderRepository struct {
 	db *gorm.DB
@@ -65,12 +71,7 @@ func (r *gormOrderRepository) List(filter OrderFilter) ([]entity.Order, int, err
 		if strings.ToUpper(filter.SortOrder) == "ASC" {
 			dir = "ASC"
 		}
-		allowed := map[string]bool{
-			"created_at": true, "order_number": true, "total_price": true,
-			"customer_name": true, "source_id": true, "financial_status": true,
-			"fulfillment_status": true,
-		}
-		if allowed[filter.SortBy] {
+		if orderListAllowedSortColumns[filter.SortBy] {
 			orderClause = filter.SortBy + " " + dir
 		}
 	}

--- a/backend/internal/service/customer_service.go
+++ b/backend/internal/service/customer_service.go
@@ -18,6 +18,12 @@ import (
 	"gorm.io/gorm"
 )
 
+var (
+	customerSearchEmptyRegex = regexp.MustCompile(`(\w+)\s*=\s*['"]{2}`)
+	customerSearchRangeRegex = regexp.MustCompile(`(\w+)\s*([><])\s*(\d+)`)
+	customerSearchKVRegex    = regexp.MustCompile(`(\w+)[:=]\s*([^ ]+)`)
+)
+
 type CustomerService struct {
 	repo          *repository.CustomerRepository
 	orderRepo     repository.OrderRepository
@@ -423,49 +429,61 @@ func (s *CustomerService) ListCustomers(ctx context.Context, f CustomerFilter) (
 
 func (s *CustomerService) parseSearchQuery(search string) CustomerFilter {
 	f := CustomerFilter{}
-	
+
 	// Support "field = ''" or "field = \"\""
-	emptyRegex := regexp.MustCompile(`(\w+)\s*=\s*['"]{2}`)
-	matches := emptyRegex.FindAllStringSubmatch(search, -1)
+	matches := customerSearchEmptyRegex.FindAllStringSubmatch(search, -1)
 	for _, m := range matches {
 		field := strings.ToLower(m[1])
 		switch field {
-		case "first_name": f.FirstNameEmpty = true
-		case "last_name": f.LastNameEmpty = true
-		case "email": f.EmailEmpty = true
+		case "first_name":
+			f.FirstNameEmpty = true
+		case "last_name":
+			f.LastNameEmpty = true
+		case "email":
+			f.EmailEmpty = true
 		}
 		search = strings.Replace(search, m[0], "", 1)
 	}
 
 	// Support "field > 1000" or "field < 5000"
-	rangeRegex := regexp.MustCompile(`(\w+)\s*([><])\s*(\d+)`)
-	matches = rangeRegex.FindAllStringSubmatch(search, -1)
+	matches = customerSearchRangeRegex.FindAllStringSubmatch(search, -1)
 	for _, m := range matches {
 		field := strings.ToLower(m[1])
 		op := m[2]
 		val, _ := strconv.ParseFloat(m[3], 64)
 		switch field {
 		case "spent":
-			if op == ">" { f.MinSpent = val } else { f.MaxSpent = val }
+			if op == ">" {
+				f.MinSpent = val
+			} else {
+				f.MaxSpent = val
+			}
 		case "orders":
-			if op == ">" { f.MinOrders = int(val) }
+			if op == ">" {
+				f.MinOrders = int(val)
+			}
 		}
 		search = strings.Replace(search, m[0], "", 1)
 	}
 
 	// Support "field:value" or "field=value"
-	kvRegex := regexp.MustCompile(`(\w+)[:=]\s*([^ ]+)`)
-	matches = kvRegex.FindAllStringSubmatch(search, -1)
+	matches = customerSearchKVRegex.FindAllStringSubmatch(search, -1)
 	for _, m := range matches {
 		field := strings.ToLower(m[1])
 		val := strings.Trim(m[2], `"'`)
 		switch field {
-		case "city": f.City = val
-		case "state": f.State = val
-		case "first_name": f.FirstName = val
-		case "last_name": f.LastName = val
-		case "email": f.Email = val
-		case "source": f.SourceID = val
+		case "city":
+			f.City = val
+		case "state":
+			f.State = val
+		case "first_name":
+			f.FirstName = val
+		case "last_name":
+			f.LastName = val
+		case "email":
+			f.Email = val
+		case "source":
+			f.SourceID = val
 		}
 		search = strings.Replace(search, m[0], "", 1)
 	}


### PR DESCRIPTION
💡 What: Pre-compiled regular expressions and moved static lookup maps to the package level in high-traffic service and repository paths.

🎯 Why: Repeatedly calling `regexp.MustCompile` and re-allocating maps within functions like search parsing and list filtering introduces unnecessary CPU and memory overhead.

📊 Impact: Reduces CPU overhead for regex compilation from O(N) calls to O(1) initialization. Eliminates redundant memory allocations for static allowlists.

🔬 Measurement: Verified with existing backend test suite. Logic remains identical but execution path is more efficient.

---
*PR created automatically by Jules for task [554933541585462634](https://jules.google.com/task/554933541585462634) started by @millennialperfumer-tech*