### PR TITLE
🛡️ Sentinel: [HIGH] Fix Permissive CORS Configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `CustomerRepository.List` passed the `sortBy` parameter from user input directly to GORM's `Order()` method without validation.
 **Learning:** ORM methods like GORM's `Order()` often do not parameterize identifiers (like column names) and instead concatenate them into the raw SQL query. This makes them a direct sink for SQL injection if the input is not strictly validated against an allowlist of permitted columns.
 **Prevention:** Always validate dynamic sorting parameters against a hardcoded allowlist map of valid column names before passing them to the database query layer.
+
+## 2026-04-26 - [Permissive CORS Hardening]
+**Vulnerability:** CORS policy echoing back any `Origin` header even when `ALLOWED_ORIGINS` contained a wildcard, potentially bypassing security when credentials were enabled.
+**Learning:** Standard CORS implementations must strictly separate wildcard behavior from credentialed behavior. Allowing credentials with a reflected origin essentially makes the wildcard uselessly dangerous.
+**Prevention:** Explicitly check for wildcards in `ALLOWED_ORIGINS`. If present, set `Access-Control-Allow-Origin` to `*` and `Access-Control-Allow-Credentials` to `false` to ensure browsers block authenticated cross-origin requests.

--- a/backend/internal/server/middleware.go
+++ b/backend/internal/server/middleware.go
@@ -22,36 +22,45 @@ func CORSMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		allowedOriginsEnv := os.Getenv("ALLOWED_ORIGINS")
 		allowedOrigins := strings.Split(allowedOriginsEnv, ",")
 		origin := r.Header.Get("Origin")
-		isAllowed := false
 
-		if origin != "" {
-			for _, allowed := range allowedOrigins {
-				trimmed := strings.TrimSpace(allowed)
-				if trimmed == "*" || origin == trimmed {
-					isAllowed = true
-					break
-				}
-			}
-		} else {
-			// If no origin, we can consider it a direct request or same-origin
-			isAllowed = true
+		if origin == "" {
+			next(w, r)
+			return
 		}
 
-		if isAllowed {
+		isExplicitlyAllowed := false
+		hasWildcard := false
+		for _, allowed := range allowedOrigins {
+			trimmed := strings.TrimSpace(allowed)
+			if trimmed == "*" {
+				hasWildcard = true
+			} else if origin == trimmed {
+				isExplicitlyAllowed = true
+				break
+			}
+		}
+
+		if isExplicitlyAllowed {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH")
-			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With, X-Amz-Date, X-Api-Key, X-Amz-Security-Token")
-		} else if origin != "" {
+		} else if hasWildcard {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Credentials", "false")
+		} else {
 			log.Printf("CORS REJECTED: Origin=[%s] not in ALLOWED_ORIGINS=[%s]", origin, allowedOriginsEnv)
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			next(w, r)
+			return
 		}
 
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With, X-Amz-Date, X-Api-Key, X-Amz-Security-Token")
+
 		if r.Method == http.MethodOptions {
-			if isAllowed {
-				w.WriteHeader(http.StatusOK)
-			} else {
-				w.WriteHeader(http.StatusForbidden)
-			}
+			w.WriteHeader(http.StatusOK)
 			return
 		}
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Permissive CORS policy mirroring request Origin even when wildcards were used, while keeping credentials enabled.
🎯 Impact: This allowed any malicious website to make authenticated API requests on behalf of a user if a wildcard was present in ALLOWED_ORIGINS.
🔧 Fix: Hardened CORSMiddleware to strictly differentiate between explicit origin matches and wildcard matches. Wildcards now set Origin to '*' and disable credentials. Requests without Origin are passed through without CORS headers.
✅ Verification: Verified via `go test ./internal/server/...` and `go test ./...` in the backend directory.

---
*PR created automatically by Jules for task [12658258777111894363](https://jules.google.com/task/12658258777111894363) started by @millennialperfumer-tech*