### PR TITLE
⚡ Bolt: Batch inventory synchronization in UpsertBatch

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2026-03-27 - [Optimizing Reporting with SQL Aggregations and Window Functions]
 **Learning:** Combining multiple metrics into a single SQL query using `FILTER` and `CASE` (conditional aggregation) eliminates redundant database roundtrips and application-side processing. For HSN/line-item reports, replacing global CTE scans with window functions (`SUM(...) OVER (PARTITION BY order_id)`) within date-filtered JOINs ensures the database only processes relevant rows, significantly improving performance as the table grows.
 **Action:** Always prefer conditional SQL aggregation over multiple repository calls for dashboard/reporting logic. Use window functions for per-group aggregations within filtered result sets to avoid full table scans.
+
+## 2026-03-28 - [Batch Inventory Synchronization in UpsertBatch]
+**Learning:** Sequential inventory synchronization within a batch order upsert creates an N+1 bottleneck. Aggregating SKU deltas across the entire batch allows for fetching mappings in a single tuple `IN` query (`WHERE (platform, sku) IN ?`) and consolidating stock updates by `InventoryItemID`. Batching the final status flags (e.g., `inventory_deducted`) further reduces overhead.
+**Action:** When implementing batch operations that involve related entities or secondary updates (like inventory or status flags), always aggregate requirements and perform bulk queries/updates instead of iterating over the primary entities.

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -61,6 +61,7 @@ type OrderRepository interface {
 type LineItemRepository interface {
 	GetByOrderID(orderID int64) ([]entity.LineItem, error)
 	UpsertBatch(tx *gorm.DB, orderID int64, items []entity.LineItem) error
+	DeleteByOrderID(tx *gorm.DB, orderID int64) error
 }
 
 // WebhookEventRepository defines data access for the webhook_events table.

--- a/backend/internal/repository/line_item_repository.go
+++ b/backend/internal/repository/line_item_repository.go
@@ -47,3 +47,9 @@ func (r *gormLineItemRepository) UpsertBatch(tx *gorm.DB, orderID int64, items [
 	return nil
 }
 
+func (r *gormLineItemRepository) DeleteByOrderID(tx *gorm.DB, orderID int64) error {
+	if err := tx.Where("order_id = ?", orderID).Delete(&entity.LineItem{}).Error; err != nil {
+		return fmt.Errorf("failed to delete line items for order %d: %w", orderID, err)
+	}
+	return nil
+}

--- a/backend/internal/repository/order_repository.go
+++ b/backend/internal/repository/order_repository.go
@@ -436,24 +436,76 @@ func (r *gormOrderRepository) UpsertBatch(orders []entity.Order) ([]int, error) 
 			}
 		}
 
-		// 4. Sync Inventory Deltas for all orders in batch
-		allAffected := make(map[int]bool)
+		// 4. Optimized Batch Sync Inventory Deltas
+		type skuKey struct {
+			Platform string
+			SKU      string
+		}
+		totalSKUDeltas := make(map[skuKey]int)
+		pairs := make([][]interface{}, 0)
+
 		for i := range orders {
-			ids, err := r.syncInventoryDeltas(tx, &orders[i], oldLinesByOrder[orders[i].ID])
-			if err != nil {
-				return err
+			// Calculate deltas for this order: New - Old
+			// Note: We use the same logic as syncInventoryDeltas to preserve behavior
+			orderSKUDeltas := make(map[string]int)
+			for _, li := range orders[i].LineItems {
+				if li.SKU != nil && *li.SKU != "" {
+					orderSKUDeltas[*li.SKU] += li.Quantity
+				}
 			}
-			for _, id := range ids {
-				allAffected[id] = true
+			for _, li := range oldLinesByOrder[orders[i].ID] {
+				if li.SKU != nil && *li.SKU != "" {
+					orderSKUDeltas[*li.SKU] -= li.Quantity
+				}
 			}
-			// Update individual order flag
-			if err := tx.Model(&orders[i]).Update("inventory_deducted", orders[i].InventoryDeducted).Error; err != nil {
-				return err
+
+			for sku, delta := range orderSKUDeltas {
+				if delta == 0 {
+					continue
+				}
+				key := skuKey{Platform: orders[i].SourceID, SKU: sku}
+				if _, exists := totalSKUDeltas[key]; !exists {
+					pairs = append(pairs, []interface{}{key.Platform, key.SKU})
+				}
+				totalSKUDeltas[key] += delta
+			}
+			orders[i].InventoryDeducted = true
+		}
+
+		if len(pairs) > 0 {
+			var mappings []entity.InventoryMapping
+			// Optimization: Batch fetch all relevant mappings in a single O(1) round-trip using tuple IN
+			if err := tx.Where("(platform, external_sku) IN ?", pairs).Find(&mappings).Error; err != nil {
+				return fmt.Errorf("failed to fetch mappings in batch: %w", err)
+			}
+
+			itemDeltas := make(map[int]int)
+			for _, m := range mappings {
+				key := skuKey{Platform: m.Platform, SKU: m.ExternalSKU}
+				itemDeltas[m.InventoryItemID] += totalSKUDeltas[key]
+			}
+
+			for itemID, delta := range itemDeltas {
+				if delta == 0 {
+					continue
+				}
+				// Optimization: Aggregate deltas by InventoryItemID to minimize update queries
+				if err := tx.Model(&entity.InventoryItem{}).
+					Where("id = ?", itemID).
+					Update("current_stock", gorm.Expr("current_stock - ?", delta)).Error; err != nil {
+					return fmt.Errorf("failed to adjust stock for item %d: %w", itemID, err)
+				}
+				affectedIDs = append(affectedIDs, itemID)
 			}
 		}
 
-		for id := range allAffected {
-			affectedIDs = append(affectedIDs, id)
+		// Optimization: Batch update inventory_deducted flag for all processed orders
+		orderIDsForFlag := make([]int64, len(orders))
+		for i := range orders {
+			orderIDsForFlag[i] = orders[i].ID
+		}
+		if err := tx.Model(&entity.Order{}).Where("id IN ?", orderIDsForFlag).Update("inventory_deducted", true).Error; err != nil {
+			return fmt.Errorf("failed to batch update inventory_deducted flag: %w", err)
 		}
 
 		return nil

--- a/backend/internal/service/mocks/repositories.go
+++ b/backend/internal/service/mocks/repositories.go
@@ -131,6 +131,11 @@ func (m *MockLineItemRepository) UpsertBatch(tx *gorm.DB, orderID int64, items [
 	args := m.Called(tx, orderID, items)
 	return args.Error(0)
 }
+
+func (m *MockLineItemRepository) DeleteByOrderID(tx *gorm.DB, orderID int64) error {
+	args := m.Called(tx, orderID)
+	return args.Error(0)
+}
 type MockInventoryRepository struct {
 	mock.Mock
 }


### PR DESCRIPTION
💡 What: Refactored the inventory synchronization logic in `OrderRepository.UpsertBatch` to use a batched strategy.
🎯 Why: The previous implementation used an N+1 query pattern, performing sequential database lookups and updates for every order in a batch, which caused significant overhead during high-volume syncs.
📊 Impact: Reduces database round-trips for inventory synchronization from O(N) to O(1) for mappings and O(M) for stock updates (where M is the number of unique inventory items, usually much smaller than N orders). Batching the `inventory_deducted` flag update also eliminates N individual update calls.
🔬 Measurement: Verified that the code compiles and passes existing repository tests. The logic utilizes efficient tuple `IN` queries and consolidated updates.

---
*PR created automatically by Jules for task [965058176555914851](https://jules.google.com/task/965058176555914851) started by @millennialperfumer-tech*