### PR TITLE
⚡ Bolt: pre-compile regex and pre-allocate allowlist maps

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-03-28 - [Batch Inventory Synchronization in UpsertBatch]
 **Learning:** Sequential inventory synchronization within a batch order upsert creates an N+1 bottleneck. Aggregating SKU deltas across the entire batch allows for fetching mappings in a single tuple `IN` query (`WHERE (platform, sku) IN ?`) and consolidating stock updates by `InventoryItemID`. Batching the final status flags (e.g., `inventory_deducted`) further reduces overhead.
 **Action:** When implementing batch operations that involve related entities or secondary updates (like inventory or status flags), always aggregate requirements and perform bulk queries/updates instead of iterating over the primary entities.
+
+## 2026-04-29 - [Regex Pre-compilation and Allowlist Map Pre-allocation]
+**Learning:** Compiling regular expressions (`regexp.MustCompile`) and allocating identical maps (e.g., sort allowlists) within frequently called functions (hot paths) introduces unnecessary overhead. Moving these to package-level variables ensures they are initialized once at startup, improving throughput and reducing garbage collection pressure without sacrificing thread safety.
+**Action:** Always move immutable regular expressions and lookup maps from function scope to package scope in critical paths like search parsing and listing repositories.

--- a/backend/internal/automation/whatsapp/webhook_mapping_service.go
+++ b/backend/internal/automation/whatsapp/webhook_mapping_service.go
@@ -16,7 +16,10 @@ import (
 	"time"
 )
 
-var phoneRegex = regexp.MustCompile(`[^0-9]`)
+var (
+	phoneRegex         = regexp.MustCompile(`[^0-9]`)
+	templateParamRegex = regexp.MustCompile(`\{\{(\d+)\}\}`)
+)
 
 func sanitizePhoneNumber(phone string) string {
 	if phone == "555-555-SHIP" {
@@ -427,8 +430,7 @@ func (s *WebhookMappingService) executeWithTemplate(storeID string, template *Au
 
 // countRequiredParams finds the maximum {{n}} placeholder in the template body.
 func (s *WebhookMappingService) countRequiredParams(body string) int {
-	re := regexp.MustCompile(`\{\{(\d+)\}\}`)
-	matches := re.FindAllStringSubmatch(body, -1)
+	matches := templateParamRegex.FindAllStringSubmatch(body, -1)
 	max := 0
 	for _, m := range matches {
 		if len(m) > 1 {

--- a/backend/internal/repository/customer_repository.go
+++ b/backend/internal/repository/customer_repository.go
@@ -13,6 +13,12 @@ type CustomerRepository struct {
 	db *gorm.DB
 }
 
+var customerListAllowedSortColumns = map[string]bool{
+	"phone_number": true, "first_name": true, "last_name": true,
+	"email": true, "city": true, "state": true, "total_orders": true,
+	"total_spent": true, "updated_at": true, "created_at": true,
+}
+
 func NewCustomerRepository(db *gorm.DB) *CustomerRepository {
 	return &CustomerRepository{db: db}
 }
@@ -162,13 +168,7 @@ func (r *CustomerRepository) List(ctx context.Context, search, sortBy, sortOrder
 	}
 
 	// Security: Use allowlist for sortBy to prevent SQL injection.
-	allowedSortColumns := map[string]bool{
-		"phone_number": true, "first_name": true, "last_name": true,
-		"email": true, "city": true, "state": true, "total_orders": true,
-		"total_spent": true, "updated_at": true, "created_at": true,
-	}
-
-	if sortBy != "" && allowedSortColumns[sortBy] {
+	if sortBy != "" && customerListAllowedSortColumns[sortBy] {
 		order := sortBy
 		if sortOrder == "ASC" || sortOrder == "DESC" {
 			order += " " + sortOrder

--- a/backend/internal/repository/order_repository.go
+++ b/backend/internal/repository/order_repository.go
@@ -19,6 +19,12 @@ type gormOrderRepository struct {
 	db *gorm.DB
 }
 
+var orderListAllowedSortColumns = map[string]bool{
+	"created_at": true, "order_number": true, "total_price": true,
+	"customer_name": true, "source_id": true, "financial_status": true,
+	"fulfillment_status": true,
+}
+
 // NewOrderRepository creates a new GORM-backed OrderRepository.
 func NewOrderRepository(db *gorm.DB) OrderRepository {
 	return &gormOrderRepository{db: db}
@@ -65,12 +71,7 @@ func (r *gormOrderRepository) List(filter OrderFilter) ([]entity.Order, int, err
 		if strings.ToUpper(filter.SortOrder) == "ASC" {
 			dir = "ASC"
 		}
-		allowed := map[string]bool{
-			"created_at": true, "order_number": true, "total_price": true,
-			"customer_name": true, "source_id": true, "financial_status": true,
-			"fulfillment_status": true,
-		}
-		if allowed[filter.SortBy] {
+		if orderListAllowedSortColumns[filter.SortBy] {
 			orderClause = filter.SortBy + " " + dir
 		}
 	}

--- a/backend/internal/service/customer_service.go
+++ b/backend/internal/service/customer_service.go
@@ -18,6 +18,12 @@ import (
 	"gorm.io/gorm"
 )
 
+var (
+	customerSearchEmptyRegex = regexp.MustCompile(`(\w+)\s*=\s*['"]{2}`)
+	customerSearchRangeRegex = regexp.MustCompile(`(\w+)\s*([><])\s*(\d+)`)
+	customerSearchKVRegex    = regexp.MustCompile(`(\w+)[:=]\s*([^ ]+)`)
+)
+
 type CustomerService struct {
 	repo          *repository.CustomerRepository
 	orderRepo     repository.OrderRepository
@@ -423,10 +429,9 @@ func (s *CustomerService) ListCustomers(ctx context.Context, f CustomerFilter) (
 
 func (s *CustomerService) parseSearchQuery(search string) CustomerFilter {
 	f := CustomerFilter{}
-	
+
 	// Support "field = ''" or "field = \"\""
-	emptyRegex := regexp.MustCompile(`(\w+)\s*=\s*['"]{2}`)
-	matches := emptyRegex.FindAllStringSubmatch(search, -1)
+	matches := customerSearchEmptyRegex.FindAllStringSubmatch(search, -1)
 	for _, m := range matches {
 		field := strings.ToLower(m[1])
 		switch field {
@@ -438,8 +443,7 @@ func (s *CustomerService) parseSearchQuery(search string) CustomerFilter {
 	}
 
 	// Support "field > 1000" or "field < 5000"
-	rangeRegex := regexp.MustCompile(`(\w+)\s*([><])\s*(\d+)`)
-	matches = rangeRegex.FindAllStringSubmatch(search, -1)
+	matches = customerSearchRangeRegex.FindAllStringSubmatch(search, -1)
 	for _, m := range matches {
 		field := strings.ToLower(m[1])
 		op := m[2]
@@ -454,8 +458,7 @@ func (s *CustomerService) parseSearchQuery(search string) CustomerFilter {
 	}
 
 	// Support "field:value" or "field=value"
-	kvRegex := regexp.MustCompile(`(\w+)[:=]\s*([^ ]+)`)
-	matches = kvRegex.FindAllStringSubmatch(search, -1)
+	matches = customerSearchKVRegex.FindAllStringSubmatch(search, -1)
 	for _, m := range matches {
 		field := strings.ToLower(m[1])
 		val := strings.Trim(m[2], `"'`)


### PR DESCRIPTION
💡 What: Moved `regexp.MustCompile` calls and sort column allowlist maps from function scopes to package-level variables across multiple critical paths (Customer Search, Order Listing, WhatsApp Template Parsing).

🎯 Why: Compiling regexes and allocating maps inside frequently called functions (hot paths) creates unnecessary CPU overhead and GC pressure. Pre-compiling them at package initialization ensures they are computed only once.

📊 Impact: Reduces per-request latency in search and listing operations by eliminating redundant allocations and regex compilations. Improves throughput under high load.

🔬 Measurement: Verified with `go test ./...` in the backend to ensure no functional regressions. Standard Go benchmarks for these functions would show reduced allocations and execution time.

---
*PR created automatically by Jules for task [8771207896595658135](https://jules.google.com/task/8771207896595658135) started by @millennialperfumer-tech*