### PR TITLE
🎨 Palette: Add 'Clear' button to Products search input

### DIFF
--- a/frontend/src/Products.tsx
+++ b/frontend/src/Products.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { API_BASE } from './api';
 import { useToast } from './ToastContext';
 
@@ -74,6 +74,7 @@ export const Products: React.FC<{ token: string | null, userRole?: string, appCo
   const [showLogsModal, setShowLogsModal] = useState(false);
   const [amazonSKUInput, setAmazonSKUInput] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [sortBy, setSortBy] = useState<string>('mi-sku-asc');
   const [isSyncing, setIsSyncing] = useState(false);
   const [showSyncModal, setShowSyncModal] = useState(false);
@@ -575,17 +576,60 @@ export const Products: React.FC<{ token: string | null, userRole?: string, appCo
         <div style={{ position: 'relative', flex: 1 }}>
           <input 
             type="text" 
+            ref={searchInputRef}
             placeholder="Search by name, MI SKU, or platform SKU..." 
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             style={{ 
               paddingLeft: '2.5rem',
+              paddingRight: searchQuery ? '2.5rem' : '1rem',
               height: '42px',
               fontSize: '0.85rem',
               border: '1px solid var(--border-color)',
-              background: 'var(--bg-input)'
+              background: 'var(--bg-input)',
+              width: '100%'
             }}
           />
+          {searchQuery && (
+            <button
+              type="button"
+              onClick={() => {
+                setSearchQuery('');
+                searchInputRef.current?.focus();
+              }}
+              aria-label="Clear search"
+              title="Clear search"
+              style={{
+                position: 'absolute',
+                right: '10px',
+                top: '50%',
+                transform: 'translateY(-50%)',
+                background: 'transparent',
+                border: 'none',
+                color: 'var(--text-tertiary)',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '4px',
+                borderRadius: '50%',
+                transition: 'all 0.2s'
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.color = 'var(--text-primary)';
+                e.currentTarget.style.background = 'var(--bg-hover)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.color = 'var(--text-tertiary)';
+                e.currentTarget.style.background = 'transparent';
+              }}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+              </svg>
+            </button>
+          )}
           <svg 
             width="16" 
             height="16" 


### PR DESCRIPTION
💡 What: Added a "Clear search" button to the Warehouse Authority (Products) search input.
🎯 Why: Allows users to quickly reset their search query without manual deletion, improving navigation speed and maintaining UX consistency with other modules like Customers and Automation.
📸 Before/After: The search input previously had no way to quickly clear text. Now, an 'X' icon appears on the right side when text is entered, providing a standard micro-interaction.
♿ Accessibility: Included `aria-label="Clear search"` for screen readers. Ensured the button is accessible via keyboard and programmatically returns focus to the input field after clearing to maintain the user's flow.

---
*PR created automatically by Jules for task [6222134731209333687](https://jules.google.com/task/6222134731209333687) started by @millennialperfumer-tech*