### PR TITLE
⚡ Bolt: hoist regex compilation in customer service

### DIFF
--- a/backend/internal/service/customer_service.go
+++ b/backend/internal/service/customer_service.go
@@ -23,6 +23,7 @@ var (
 	customerSearchEmptyRegex = regexp.MustCompile(`(\w+)\s*=\s*['"]{2}`)
 	customerSearchRangeRegex = regexp.MustCompile(`(\w+)\s*([><])\s*(\d+)`)
 	customerSearchKVRegex    = regexp.MustCompile(`(\w+)[:=]\s*([^ ]+)`)
+	nonDigitRegex            = regexp.MustCompile(`\D`)
 )
 
 type CustomerService struct {
@@ -783,8 +784,7 @@ func (s *CustomerService) ExportMetaCSV(ctx context.Context, boughtOnly bool) ([
 
 func (s *CustomerService) cleanMetaPhone(phone string) string {
 	// Replicate Python: re.sub(r"\D", "", phone)
-	reg := regexp.MustCompile(`\D`)
-	cleaned := reg.ReplaceAllString(phone, "")
+	cleaned := nonDigitRegex.ReplaceAllString(phone, "")
 
 	if len(cleaned) == 10 {
 		return "91" + cleaned


### PR DESCRIPTION
💡 What:
Hoisted the `\D` regular expression compilation in the `cleanMetaPhone` function to a package-level variable `nonDigitRegex`.

🎯 Why:
The `cleanMetaPhone` function is called within a loop in `ExportMetaCSV`, which can process thousands of customers during a CSV export. Previously, `regexp.MustCompile` was called for every single customer record, leading to redundant CPU cycles and memory allocations for compiling the same regular expression repeatedly.

📊 Impact:
Reduces CPU overhead and memory allocations during large CSV exports. For an export of 100,000 customers, it saves 100,000 redundant regex compilations.

🔬 Measurement:
Verified by running the backend test suite (`go test ./...`) to ensure no regressions in phone number cleaning logic.

---
*PR created automatically by Jules for task [2997857675104594857](https://jules.google.com/task/2997857675104594857) started by @millennialperfumer-tech*