### PR TITLE
🛡️ Sentinel: Harden sensitive comparisons against timing attacks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `CustomerRepository.List` passed the `sortBy` parameter from user input directly to GORM's `Order()` method without validation.
 **Learning:** ORM methods like GORM's `Order()` often do not parameterize identifiers (like column names) and instead concatenate them into the raw SQL query. This makes them a direct sink for SQL injection if the input is not strictly validated against an allowlist of permitted columns.
 **Prevention:** Always validate dynamic sorting parameters against a hardcoded allowlist map of valid column names before passing them to the database query layer.
+
+## 2026-03-31 - [Timing Side-Channel Attacks in Sensitive Comparisons]
+**Vulnerability:** Use of standard string equality (== or !=) for comparing sensitive secrets like HMAC signatures, Webhook verification tokens, and OTP codes.
+**Learning:** Standard string comparison in most languages, including Go, exits early upon the first mismatching character. This allows an attacker to measure the response time to incrementally guess the correct secret, one character at a time.
+**Prevention:** Always use constant-time comparison functions like `crypto/subtle.ConstantTimeCompare` when verifying sensitive security tokens, signatures, or passwords to ensure execution time is independent of the input values.

--- a/backend/internal/handler/marketing_webhook_handler.go
+++ b/backend/internal/handler/marketing_webhook_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"mi-tech/internal/config"
 	"mi-tech/internal/marketing"
@@ -43,7 +44,7 @@ func (h *MarketingWebhookHandler) verifyWebhook(w http.ResponseWriter, r *http.R
 
 	expectedToken := h.settings.GetMetaMarketingWebhookVerifyToken()
 
-	if mode == "subscribe" && token == expectedToken {
+	if mode == "subscribe" && subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1 {
 		fmt.Printf("Meta Marketing Webhook verified successfully!\n")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(challenge))

--- a/backend/internal/handler/webhook_handler.go
+++ b/backend/internal/handler/webhook_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -270,7 +271,7 @@ func (h *WebhookHandler) verifyWebhook(r *http.Request, body []byte) bool {
 	hash.Write(body)
 	expectedHmac := base64.StdEncoding.EncodeToString(hash.Sum(nil))
 
-	isMatch := hmacHeader == expectedHmac
+	isMatch := subtle.ConstantTimeCompare([]byte(hmacHeader), []byte(expectedHmac)) == 1
 	if !isMatch {
 		log.Printf("Webhook HMAC Mismatch!")
 		log.Printf("  Received: %s", hmacHeader)

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"crypto/rand"
+	"crypto/subtle"
 	"io"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -126,7 +127,7 @@ func (s *AuthService) VerifyOTP(username, otp string) (string, error) {
 		return "", errors.New("verification code expired or not found")
 	}
 
-	if user.OTPCode != otp {
+	if subtle.ConstantTimeCompare([]byte(user.OTPCode), []byte(otp)) != 1 {
 		return "", errors.New("invalid verification code")
 	}
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Timing side-channel attacks in sensitive string comparisons.
🎯 Impact: Attackers could potentially guess sensitive secrets (HMAC signatures, webhook tokens, OTPs) by measuring response times.
🔧 Fix: Implemented `crypto/subtle.ConstantTimeCompare` for Shopify HMAC, Meta Webhook tokens, and OTP verification.
✅ Verification: Ran all backend tests (\`go test ./...\`) and they passed. Verified the changes in the source code.

---
*PR created automatically by Jules for task [16069782249081922030](https://jules.google.com/task/16069782249081922030) started by @millennialperfumer-tech*