### PR TITLE
⚡ Bolt: Optimize HSN report aggregation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-04-30 - [Regex Pre-compilation and static sort allowlisting]
 **Learning:** Avoid repeatedly calling `regexp.MustCompile` or allocating the same map within high-frequency functions (like request handlers or search parsers). Hoisting these to package-level variables reduces CPU cycles and memory allocations per request.
 **Action:** Always check for repeated regex compilation or constant map allocations in hot paths and move them to package-level variables.
+
+## 2026-05-15 - [Pushing Aggregation to Database]
+**Learning:** Application-side aggregation of report data (e.g., using maps to group by HSN code and manual loops for tax splits) is less efficient than SQL-level aggregation. Pushing `GROUP BY` and conditional logic (`CASE WHEN`) into the database reduces data transfer and leverages the DB's optimized execution engine.
+**Action:** Always evaluate if reporting metrics can be fully computed in a single SQL query before resorting to application-side post-processing. Use `COALESCE` and `NULLIF` to ensure consistent grouping keys when dealing with nullable or empty string columns.

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -116,11 +116,13 @@ type StateSummaryResult struct {
 
 type HSNSummaryResult struct {
 	HSNCode      string
-	State        string
 	ProductCount int
 	QtySold      int
 	TaxableValue float64
 	TotalGST     float64
+	CGST         float64
+	SGST         float64
+	IGST         float64
 	Revenue      float64
 }
 

--- a/backend/internal/repository/report_repository.go
+++ b/backend/internal/repository/report_repository.go
@@ -127,11 +127,11 @@ func (r *gormReportRepository) GetStateSummary(startDate, endDate string) ([]Sta
 func (r *gormReportRepository) GetHSNSummary(startDate, endDate string) ([]HSNSummaryResult, error) {
 	start, end := parseDateRange(startDate, endDate)
 
-		query := `
+	query := `
 		WITH LineItemShares AS (
 			SELECT 
 				li.order_id,
-				COALESCE(li.hs_code, '33029019') as hs_code,
+				COALESCE(NULLIF(li.hs_code, ''), '33029019') as hs_code,
 				li.quantity,
 				(li.price * li.quantity - li.discount) as line_val,
 				SUM(li.price * li.quantity - li.discount) OVER (PARTITION BY li.order_id) as line_sum,
@@ -149,11 +149,13 @@ func (r *gormReportRepository) GetHSNSummary(startDate, endDate string) ([]HSNSu
 			SUM(quantity) as qty_sold,
 			ROUND(SUM((line_val / line_sum) * order_taxable), 2) as taxable_value,
 			ROUND(SUM((line_val / line_sum) * order_tax), 2) as total_gst,
-			ROUND(SUM((line_val / line_sum) * total_price), 2) as revenue,
-			state
+			ROUND(SUM(CASE WHEN LOWER(state) IN ('tamil nadu', 'tn', 'tamilnadu') THEN (line_val / line_sum) * order_tax / 2 ELSE 0 END), 2) as cgst,
+			ROUND(SUM(CASE WHEN LOWER(state) IN ('tamil nadu', 'tn', 'tamilnadu') THEN (line_val / line_sum) * order_tax / 2 ELSE 0 END), 2) as sgst,
+			ROUND(SUM(CASE WHEN COALESCE(LOWER(state), '') NOT IN ('tamil nadu', 'tn', 'tamilnadu') THEN (line_val / line_sum) * order_tax ELSE 0 END), 2) as igst,
+			ROUND(SUM((line_val / line_sum) * total_price), 2) as revenue
 		FROM LineItemShares
 		WHERE line_sum > 0
-		GROUP BY hs_code, state
+		GROUP BY hs_code
 		ORDER BY revenue DESC
 	`
 

--- a/backend/internal/repository/report_repository_test.go
+++ b/backend/internal/repository/report_repository_test.go
@@ -143,6 +143,9 @@ func (s *MetricsReportRepositoryTestSuite) TestGetHSNSummary() {
 			found = true
 			assert.Equal(s.T(), 100.0, r.TaxableValue)
 			assert.Equal(s.T(), 18.0, r.TotalGST)
+			assert.Equal(s.T(), 9.0, r.CGST)
+			assert.Equal(s.T(), 9.0, r.SGST)
+			assert.Equal(s.T(), 0.0, r.IGST)
 			assert.Equal(s.T(), 118.0, r.Revenue)
 		}
 	}

--- a/backend/internal/service/report_service.go
+++ b/backend/internal/service/report_service.go
@@ -77,35 +77,23 @@ func (s *ReportService) GetHSNSummary(startDate, endDate string) ([]dto.HSNSumma
 		return nil, err
 	}
 
-	// Aggregate by HSN code (results are per HSN+State)
-	hsnMap := make(map[string]*dto.HSNSummaryRow)
+	var rows []dto.HSNSummaryRow
 	for _, r := range results {
 		hsn := r.HSNCode
 		if hsn == "" {
 			hsn = "33029019"
 		}
-
-		if _, ok := hsnMap[hsn]; !ok {
-			hsnMap[hsn] = &dto.HSNSummaryRow{HSNCode: hsn}
-		}
-		row := hsnMap[hsn]
-		row.ProductCount += r.ProductCount
-		row.QtySold += r.QtySold
-		row.TaxableValue += r.TaxableValue
-		row.TotalGST += r.TotalGST
-		row.Revenue += r.Revenue
-
-		if isTamilNadu(r.State) {
-			row.CGST += r.TotalGST / 2
-			row.SGST += r.TotalGST / 2
-		} else {
-			row.IGST += r.TotalGST
-		}
-	}
-
-	var rows []dto.HSNSummaryRow
-	for _, v := range hsnMap {
-		rows = append(rows, *v)
+		rows = append(rows, dto.HSNSummaryRow{
+			HSNCode:      hsn,
+			ProductCount: r.ProductCount,
+			QtySold:      r.QtySold,
+			TaxableValue: r.TaxableValue,
+			TotalGST:     r.TotalGST,
+			CGST:         r.CGST,
+			SGST:         r.SGST,
+			IGST:         r.IGST,
+			Revenue:      r.Revenue,
+		})
 	}
 	return rows, nil
 }


### PR DESCRIPTION
This PR implements a performance optimization for the HSN-wise GST reporting system. By pushing the aggregation and tax-splitting logic down to the database layer, we reduce the amount of data processed in-memory and minimize the communication overhead between the backend and the database.

### 💡 What
- **Repository Layer:** Refactored the SQL query in `GetHSNSummary` to use `GROUP BY hs_code` and conditional `SUM(CASE WHEN ...)` for GST splits.
- **Interface Layer:** Updated `HSNSummaryResult` to include pre-calculated tax fields.
- **Service Layer:** Removed the complex manual aggregation logic in `ReportService`, making it a lean mapping function.

### 🎯 Why
The previous implementation fetched results grouped by both HSN and State, then manually aggregated them into a map in Go while performing conditional checks for tax splits. This was inefficient for large datasets.

### 📊 Impact
- **Lower Latency:** Aggregation is now handled by the optimized PostgreSQL engine.
- **Reduced Memory Usage:** No more large temporary maps in the Go service layer.

### 🔬 Measurement
Verified with `cd backend && go test ./...`. Repository tests now explicitly check for the correct tax split calculation at the DB level.

### ♿ Accessibility
N/A (Backend logic change)

---
*PR created automatically by Jules for task [13947502844282035185](https://jules.google.com/task/13947502844282035185) started by @millennialperfumer-tech*