### PR TITLE
🛡️ Sentinel: [HIGH] Harden WhatsApp Webhook verification

### DIFF
--- a/backend/internal/automation/whatsapp/handlers.go
+++ b/backend/internal/automation/whatsapp/handlers.go
@@ -3,6 +3,7 @@ package whatsapp
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -177,12 +178,23 @@ func (h *AutomationHandler) SyncTemplateStatus(w http.ResponseWriter, r *http.Re
 func (h *AutomationHandler) WhatsAppWebhook(w http.ResponseWriter, r *http.Request) {
 	// 1. Hub Challenge for verification
 	if r.Method == http.MethodGet {
-		challenge := r.URL.Query().Get("hub.challenge")
-		if challenge != "" {
+		query := r.URL.Query()
+		mode := query.Get("hub.mode")
+		token := query.Get("hub.verify_token")
+		challenge := query.Get("hub.challenge")
+
+		expectedToken := h.settings.GetWhatsAppWebhookVerifyToken()
+
+		if mode == "subscribe" && expectedToken != "" && subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1 {
+			log.Printf("WhatsApp Webhook verified successfully!")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(challenge))
 			return
 		}
+
+		log.Printf("WhatsApp Webhook verification failed: mode=%s, token=%s", mode, token)
+		http.Error(w, "Verification failed", http.StatusForbidden)
+		return
 	}
 
 	// 2. Handle status updates


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Harden WhatsApp Webhook verification

#### 🚨 Severity: HIGH

#### 💡 Vulnerability
The WhatsApp Webhook GET handler was returning the `hub.challenge` without verifying the `hub.verify_token` or `hub.mode`.

#### 🎯 Impact
Any external party could verify a webhook against the endpoint by simply providing a `hub.challenge` parameter, bypassing the authentication mechanism intended by Meta.

#### 🔧 Fix
- Updated `backend/internal/automation/whatsapp/handlers.go` to validate that `hub.mode` is "subscribe".
- Implemented `subtle.ConstantTimeCompare` to verify the `hub.verify_token` against the configured secret retrieved from `h.settings.GetWhatsAppWebhookVerifyToken()`.
- Added `crypto/subtle` to imports to prevent timing side-channel attacks.

#### ✅ Verification
- Verified code changes using `sed`.
- Ran all backend tests using `go test ./...` and `go vet ./...` - all passed.
- Manually confirmed the logic correctly handles both valid and invalid verification attempts.

---
*PR created automatically by Jules for task [7795616622087447484](https://jules.google.com/task/7795616622087447484) started by @millennialperfumer-tech*