### PR TITLE
🎨 Palette: Improve Suppliers UX with search clear button and accessibility

### DIFF
--- a/frontend/src/Suppliers.tsx
+++ b/frontend/src/Suppliers.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { API_BASE } from './api';
 import { useToast } from './ToastContext';
+import { useConfirm } from './ConfirmContext';
 
 interface Supplier {
   id: number;
@@ -10,12 +11,14 @@ interface Supplier {
 
 export const Suppliers: React.FC<{ token: string | null }> = ({ token }) => {
   const { success: toastSuccess, error: toastError } = useToast();
+  const { confirm: customConfirm } = useConfirm();
   const [suppliers, setSuppliers] = useState<Supplier[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [showAddModal, setShowAddModal] = useState(false);
   const [formData, setFormData] = useState({ name: '', contact_info: '' });
   const [editingId, setEditingId] = useState<number | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const fetchWithAuth = async (url: string, options: RequestInit = {}) => {
     const headers = {
@@ -64,7 +67,13 @@ export const Suppliers: React.FC<{ token: string | null }> = ({ token }) => {
   };
 
   const handleDelete = async (id: number) => {
-    if (!window.confirm('Are you sure you want to delete this supplier?')) return;
+    const confirmed = await customConfirm({
+      title: 'Delete Supplier',
+      message: 'Are you sure you want to delete this supplier? This action cannot be undone.',
+      variant: 'danger',
+      confirmLabel: 'Delete'
+    });
+    if (!confirmed) return;
     try {
       const resp = await fetchWithAuth(`${API_BASE}/api/inventory/suppliers?id=${id}`, {
         method: 'DELETE'
@@ -106,12 +115,23 @@ export const Suppliers: React.FC<{ token: string | null }> = ({ token }) => {
         <div style={{ position: 'relative', flex: 1, maxWidth: '400px' }}>
           <input 
             type="text" 
+            ref={searchInputRef}
             placeholder="Search suppliers by name or contact..." 
             className="search-input" 
             value={searchQuery}
             onChange={e => setSearchQuery(e.target.value)}
-            style={{ width: '100%', paddingLeft: '2.75rem', height: '44px', borderRadius: '12px' }}
+            style={{ width: '100%', paddingLeft: '2.75rem', paddingRight: searchQuery ? '2.5rem' : '1rem', height: '44px', borderRadius: '12px' }}
           />
+          {searchQuery && (
+            <button
+              type="button"
+              onClick={() => { setSearchQuery(''); searchInputRef.current?.focus(); }}
+              aria-label="Clear search"
+              style={{ position: 'absolute', right: '10px', top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', color: 'var(--text-tertiary)', cursor: 'pointer', display: 'flex', alignItems: 'center' }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+            </button>
+          )}
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--text-tertiary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ position: 'absolute', left: '1rem', top: '50%', transform: 'translateY(-50%)' }}>
             <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
           </svg>
@@ -164,12 +184,12 @@ export const Suppliers: React.FC<{ token: string | null }> = ({ token }) => {
                   </td>
                   <td style={{ paddingRight: '2rem', textAlign: 'right' }}>
                     <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
-                      <button className="toolbar-btn" style={{ background: 'var(--bg-input)', width: '36px', height: '36px', borderRadius: '10px' }} onClick={() => { setEditingId(s.id); setFormData({ name: s.name, contact_info: s.contact_info }); setShowAddModal(true); }}>
+                      <button className="toolbar-btn" style={{ background: 'var(--bg-input)', width: '36px', height: '36px', borderRadius: '10px' }} onClick={() => { setEditingId(s.id); setFormData({ name: s.name, contact_info: s.contact_info }); setShowAddModal(true); }} aria-label={`Edit ${s.name}`} title={`Edit ${s.name}`}>
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                           <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
                         </svg>
                       </button>
-                      <button className="toolbar-btn" style={{ background: 'rgba(239, 68, 68, 0.08)', color: '#ef4444', width: '36px', height: '36px', borderRadius: '10px' }} onClick={() => handleDelete(s.id)}>
+                      <button className="toolbar-btn" style={{ background: 'rgba(239, 68, 68, 0.08)', color: '#ef4444', width: '36px', height: '36px', borderRadius: '10px' }} onClick={() => handleDelete(s.id)} aria-label={`Delete ${s.name}`} title={`Delete ${s.name}`}>
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                           <polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/>
                         </svg>


### PR DESCRIPTION
### 💡 What
- Added an absolute-positioned 'Clear' button to the Suppliers search input.
- Implemented focus restoration for the search input using `useRef`.
- Replaced the native `window.confirm` browser dialog with the project's custom `useConfirm` hook for supplier deletion.
- Added `aria-label` and `title` attributes to the Edit and Delete icon buttons in the suppliers table.

### 🎯 Why
- **Search Efficiency:** Users can now reset their search query with a single click.
- **Visual Consistency:** The deletion confirmation now uses the application's design system instead of a generic browser prompt.
- **Accessibility:** Screen reader users will now receive proper context for the icon-only action buttons.
- **UX Polish:** Focus restoration ensures a seamless keyboard experience when clearing searches.

### 📸 Before/After
- **Before:** Manual backspacing needed to clear searches; generic browser alerts for deletion; unlabeled icon buttons.
- **After:** Quick 'X' button to clear; themed confirmation modal; accessible labels and tooltips.

### ♿ Accessibility
- Added descriptive `aria-label` and `title` to all icon-only buttons.
- Implemented programmatic focus management for the search input.
- Used semantic HTML button types.

---
*PR created automatically by Jules for task [350118184792567320](https://jules.google.com/task/350118184792567320) started by @millennialperfumer-tech*