### PR TITLE
⚡ Bolt: Optimize HSN report aggregation

### DIFF
--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -116,11 +116,13 @@ type StateSummaryResult struct {
 
 type HSNSummaryResult struct {
 	HSNCode      string
-	State        string
 	ProductCount int
 	QtySold      int
 	TaxableValue float64
 	TotalGST     float64
+	CGST         float64
+	SGST         float64
+	IGST         float64
 	Revenue      float64
 }
 

--- a/backend/internal/repository/report_repository.go
+++ b/backend/internal/repository/report_repository.go
@@ -127,7 +127,7 @@ func (r *gormReportRepository) GetStateSummary(startDate, endDate string) ([]Sta
 func (r *gormReportRepository) GetHSNSummary(startDate, endDate string) ([]HSNSummaryResult, error) {
 	start, end := parseDateRange(startDate, endDate)
 
-		query := `
+	query := `
 		WITH LineItemShares AS (
 			SELECT 
 				li.order_id,
@@ -138,7 +138,7 @@ func (r *gormReportRepository) GetHSNSummary(startDate, endDate string) ([]HSNSu
 				o.total_price,
 				ROUND(o.total_price / 1.18, 2) as order_taxable,
 				(o.total_price - ROUND(o.total_price / 1.18, 2)) as order_tax,
-				COALESCE(o.customer_state, 'N/A') as state
+				COALESCE(LOWER(TRIM(o.customer_state)), 'n/a') as state
 			FROM order_line_items li
 			JOIN orders o ON li.order_id = o.id
 			WHERE o.created_at >= ? AND o.created_at <= ? AND (o.status IS NULL OR LOWER(o.status) != 'cancelled')
@@ -149,11 +149,13 @@ func (r *gormReportRepository) GetHSNSummary(startDate, endDate string) ([]HSNSu
 			SUM(quantity) as qty_sold,
 			ROUND(SUM((line_val / line_sum) * order_taxable), 2) as taxable_value,
 			ROUND(SUM((line_val / line_sum) * order_tax), 2) as total_gst,
-			ROUND(SUM((line_val / line_sum) * total_price), 2) as revenue,
-			state
+			ROUND(SUM(CASE WHEN state IN ('tamil nadu', 'tn', 'tamilnadu') THEN ((line_val / line_sum) * order_tax) / 2 ELSE 0 END), 2) as cgst,
+			ROUND(SUM(CASE WHEN state IN ('tamil nadu', 'tn', 'tamilnadu') THEN ((line_val / line_sum) * order_tax) / 2 ELSE 0 END), 2) as sgst,
+			ROUND(SUM(CASE WHEN state NOT IN ('tamil nadu', 'tn', 'tamilnadu') THEN ((line_val / line_sum) * order_tax) ELSE 0 END), 2) as igst,
+			ROUND(SUM((line_val / line_sum) * total_price), 2) as revenue
 		FROM LineItemShares
 		WHERE line_sum > 0
-		GROUP BY hs_code, state
+		GROUP BY hs_code
 		ORDER BY revenue DESC
 	`
 

--- a/backend/internal/repository/report_repository_test.go
+++ b/backend/internal/repository/report_repository_test.go
@@ -141,8 +141,13 @@ func (s *MetricsReportRepositoryTestSuite) TestGetHSNSummary() {
 	for _, r := range results {
 		if r.HSNCode == "123456" {
 			found = true
+			assert.Equal(s.T(), 1, r.ProductCount)
+			assert.Equal(s.T(), 1, r.QtySold)
 			assert.Equal(s.T(), 100.0, r.TaxableValue)
 			assert.Equal(s.T(), 18.0, r.TotalGST)
+			assert.Equal(s.T(), 9.0, r.CGST)
+			assert.Equal(s.T(), 9.0, r.SGST)
+			assert.Equal(s.T(), 0.0, r.IGST)
 			assert.Equal(s.T(), 118.0, r.Revenue)
 		}
 	}

--- a/backend/internal/service/mocks/repositories.go
+++ b/backend/internal/service/mocks/repositories.go
@@ -209,3 +209,12 @@ func (m *MockInventoryRepository) GetItemByPlatformSKU(platform, externalSKU str
 	args := m.Called(platform, externalSKU)
 	return args.Get(0).(entity.InventoryItem), args.Error(1)
 }
+
+func (m *MockInventoryRepository) WithTx(tx *gorm.DB) repository.InventoryRepository {
+	return m
+}
+
+func (m *MockInventoryRepository) GetLogsByExternalOrderID(externalOrderID string) ([]entity.InventoryLog, error) {
+	args := m.Called(externalOrderID)
+	return args.Get(0).([]entity.InventoryLog), args.Error(1)
+}

--- a/backend/internal/service/report_service.go
+++ b/backend/internal/service/report_service.go
@@ -77,35 +77,24 @@ func (s *ReportService) GetHSNSummary(startDate, endDate string) ([]dto.HSNSumma
 		return nil, err
 	}
 
-	// Aggregate by HSN code (results are per HSN+State)
-	hsnMap := make(map[string]*dto.HSNSummaryRow)
+	var rows []dto.HSNSummaryRow
 	for _, r := range results {
 		hsn := r.HSNCode
 		if hsn == "" {
 			hsn = "33029019"
 		}
 
-		if _, ok := hsnMap[hsn]; !ok {
-			hsnMap[hsn] = &dto.HSNSummaryRow{HSNCode: hsn}
-		}
-		row := hsnMap[hsn]
-		row.ProductCount += r.ProductCount
-		row.QtySold += r.QtySold
-		row.TaxableValue += r.TaxableValue
-		row.TotalGST += r.TotalGST
-		row.Revenue += r.Revenue
-
-		if isTamilNadu(r.State) {
-			row.CGST += r.TotalGST / 2
-			row.SGST += r.TotalGST / 2
-		} else {
-			row.IGST += r.TotalGST
-		}
-	}
-
-	var rows []dto.HSNSummaryRow
-	for _, v := range hsnMap {
-		rows = append(rows, *v)
+		rows = append(rows, dto.HSNSummaryRow{
+			HSNCode:      hsn,
+			ProductCount: r.ProductCount,
+			QtySold:      r.QtySold,
+			TaxableValue: r.TaxableValue,
+			TotalGST:     r.TotalGST,
+			CGST:         r.CGST,
+			SGST:         r.SGST,
+			IGST:         r.IGST,
+			Revenue:      r.Revenue,
+		})
 	}
 	return rows, nil
 }
@@ -141,6 +130,6 @@ func (s *ReportService) GetDocumentsIssued(startDate, endDate string) ([]dto.Doc
 
 // isTamilNadu checks if a state string refers to Tamil Nadu for CGST/SGST vs IGST split.
 func isTamilNadu(state string) bool {
-	s := strings.TrimSpace(state)
-	return len(s) > 0 && (s == "Tamil Nadu" || s == "TN" || strings.EqualFold(s, "tamil nadu"))
+	s := strings.ToLower(strings.TrimSpace(state))
+	return s == "tamil nadu" || s == "tn" || s == "tamilnadu"
 }


### PR DESCRIPTION
💡 What: Shifted HSN report aggregation and GST tax splitting (CGST/SGST/IGST) from the Go service layer into a single optimized SQL query using conditional aggregation and window functions.

🎯 Why: The previous implementation performed manual map-based aggregation in the application layer, which was inefficient for large datasets. By pushing this logic to the database, we reduce memory allocations, CPU cycles, and data transfer overhead.

📊 Impact: 
- Reduces database result set size for HSN reports.
- Eliminates O(N) aggregation loop in the backend service.
- Improves consistency of state-based tax logic between dashboard and reports.

🔬 Measurement: Verified via `backend/internal/repository/report_repository_test.go` with specific assertions for the new tax fields, `ProductCount`, and `QtySold`. All repository and service tests pass.

---
*PR created automatically by Jules for task [16239953126208904288](https://jules.google.com/task/16239953126208904288) started by @millennialperfumer-tech*