### PR TITLE
🛡️ Sentinel: [security improvement] Harden token comparisons against timing attacks

### DIFF
--- a/backend/internal/automation/whatsapp/handlers.go
+++ b/backend/internal/automation/whatsapp/handlers.go
@@ -177,12 +177,20 @@ func (h *AutomationHandler) SyncTemplateStatus(w http.ResponseWriter, r *http.Re
 func (h *AutomationHandler) WhatsAppWebhook(w http.ResponseWriter, r *http.Request) {
 	// 1. Hub Challenge for verification
 	if r.Method == http.MethodGet {
-		challenge := r.URL.Query().Get("hub.challenge")
-		if challenge != "" {
+		query := r.URL.Query()
+		mode := query.Get("hub.mode")
+		token := query.Get("hub.verify_token")
+		challenge := query.Get("hub.challenge")
+
+		expectedToken := h.settings.GetWhatsAppWebhookVerifyToken()
+
+		if mode == "subscribe" && hmac.Equal([]byte(token), []byte(expectedToken)) {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(challenge))
 			return
 		}
+		http.Error(w, "Verification failed", http.StatusForbidden)
+		return
 	}
 
 	// 2. Handle status updates

--- a/backend/internal/handler/marketing_webhook_handler.go
+++ b/backend/internal/handler/marketing_webhook_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"crypto/hmac"
 	"fmt"
 	"mi-tech/internal/config"
 	"mi-tech/internal/marketing"
@@ -43,7 +44,7 @@ func (h *MarketingWebhookHandler) verifyWebhook(w http.ResponseWriter, r *http.R
 
 	expectedToken := h.settings.GetMetaMarketingWebhookVerifyToken()
 
-	if mode == "subscribe" && token == expectedToken {
+	if mode == "subscribe" && hmac.Equal([]byte(token), []byte(expectedToken)) {
 		fmt.Printf("Meta Marketing Webhook verified successfully!\n")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(challenge))

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"crypto/rand"
+	"crypto/subtle"
 	"io"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -126,7 +127,7 @@ func (s *AuthService) VerifyOTP(username, otp string) (string, error) {
 		return "", errors.New("verification code expired or not found")
 	}
 
-	if user.OTPCode != otp {
+	if subtle.ConstantTimeCompare([]byte(user.OTPCode), []byte(otp)) != 1 {
 		return "", errors.New("invalid verification code")
 	}
 

--- a/backend/internal/service/mocks/repositories.go
+++ b/backend/internal/service/mocks/repositories.go
@@ -209,3 +209,13 @@ func (m *MockInventoryRepository) GetItemByPlatformSKU(platform, externalSKU str
 	args := m.Called(platform, externalSKU)
 	return args.Get(0).(entity.InventoryItem), args.Error(1)
 }
+
+func (m *MockInventoryRepository) WithTx(tx *gorm.DB) repository.InventoryRepository {
+	args := m.Called(tx)
+	return args.Get(0).(repository.InventoryRepository)
+}
+
+func (m *MockInventoryRepository) GetLogsByExternalOrderID(externalOrderID string) ([]entity.InventoryLog, error) {
+	args := m.Called(externalOrderID)
+	return args.Get(0).([]entity.InventoryLog), args.Error(1)
+}


### PR DESCRIPTION
This PR hardens the application against timing side-channel attacks by implementing constant-time comparisons for sensitive tokens and OTPs.

🚨 Severity: MEDIUM (Security Improvement)
💡 Vulnerability: Sensitive tokens (OTPs and Webhook verify tokens) were being compared using standard string equality (`==`), which is susceptible to timing side-channel attacks.
🎯 Impact: An attacker could potentially deduce secret tokens by measuring the response time of the server for different inputs.
🛠️ Fix: Implemented `subtle.ConstantTimeCompare` for OTP verification and `hmac.Equal` for webhook token verification.
✅ Verification: Ran `cd backend && go test ./... && go vet ./...`. All tests passed.

Additionally, I updated `MockInventoryRepository` to implement the `WithTx` and `GetLogsByExternalOrderID` methods, which were missing and causing build failures in the `internal/service` test suite.

---
*PR created automatically by Jules for task [8778027301901423295](https://jules.google.com/task/8778027301901423295) started by @millennialperfumer-tech*