### PR TITLE
⚡ Bolt: Cache Shopify primary location ID

### DIFF
--- a/backend/internal/client/shopify/client.go
+++ b/backend/internal/client/shopify/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"io"
 	"io/ioutil"
 	"log"
@@ -18,6 +19,10 @@ import (
 type Client struct {
 	settings   *config.SettingsProvider
 	httpClient *http.Client
+
+	// Performance: Cache the discovered location ID to avoid redundant GraphQL calls
+	locationCacheMu      sync.RWMutex
+	discoveredLocationID string
 }
 
 func NewClient(settings *config.SettingsProvider) *Client {
@@ -698,6 +703,15 @@ func (c *Client) GetLocationID() string {
 
 // DiscoverPrimaryLocationID fetches all locations and finds the best match.
 func (c *Client) DiscoverPrimaryLocationID(ctx context.Context) (string, error) {
+	// Performance: Return cached location ID if available
+	c.locationCacheMu.RLock()
+	if c.discoveredLocationID != "" {
+		id := c.discoveredLocationID
+		c.locationCacheMu.RUnlock()
+		return id, nil
+	}
+	c.locationCacheMu.RUnlock()
+
 	shopifyURL := c.settings.GetShopifyStoreURL()
 	accessToken := c.settings.GetShopifyAccessToken()
 
@@ -755,25 +769,39 @@ func (c *Client) DiscoverPrimaryLocationID(ctx context.Context) (string, error) 
 		return "", fmt.Errorf("no locations found in shopify store")
 	}
 
+	var finalID string
 	// 1. Priority Match: "Millennial Perfumer - WH"
 	for _, edge := range edges {
 		if strings.TrimSpace(strings.ToLower(edge.Node.Name)) == "millennial perfumer - wh" {
 			log.Printf("Shopify Discovery: Matched target location by name: %s", edge.Node.Name)
-			return edge.Node.ID, nil
+			finalID = edge.Node.ID
+			break
 		}
 	}
 
 	// 2. Secondary Match: isPrimary
-	for _, edge := range edges {
-		if edge.Node.IsPrimary {
-			log.Printf("Shopify Discovery: Using primary location: %s", edge.Node.Name)
-			return edge.Node.ID, nil
+	if finalID == "" {
+		for _, edge := range edges {
+			if edge.Node.IsPrimary {
+				log.Printf("Shopify Discovery: Using primary location: %s", edge.Node.Name)
+				finalID = edge.Node.ID
+				break
+			}
 		}
 	}
 
 	// 3. Last Resort: First one
-	log.Printf("Shopify Discovery: Using first available location: %s", edges[0].Node.Name)
-	return edges[0].Node.ID, nil
+	if finalID == "" {
+		log.Printf("Shopify Discovery: Using first available location: %s", edges[0].Node.Name)
+		finalID = edges[0].Node.ID
+	}
+
+	// Performance: Update cache
+	c.locationCacheMu.Lock()
+	c.discoveredLocationID = finalID
+	c.locationCacheMu.Unlock()
+
+	return finalID, nil
 }
 
 // AdjustInventoryLevel updates the stock level for a specific inventory item at a specific location.

--- a/backend/internal/service/mocks/repositories.go
+++ b/backend/internal/service/mocks/repositories.go
@@ -209,3 +209,13 @@ func (m *MockInventoryRepository) GetItemByPlatformSKU(platform, externalSKU str
 	args := m.Called(platform, externalSKU)
 	return args.Get(0).(entity.InventoryItem), args.Error(1)
 }
+
+func (m *MockInventoryRepository) WithTx(tx *gorm.DB) repository.InventoryRepository {
+	args := m.Called(tx)
+	return args.Get(0).(repository.InventoryRepository)
+}
+
+func (m *MockInventoryRepository) GetLogsByExternalOrderID(externalOrderID string) ([]entity.InventoryLog, error) {
+	args := m.Called(externalOrderID)
+	return args.Get(0).([]entity.InventoryLog), args.Error(1)
+}


### PR DESCRIPTION
💡 What: Implemented a thread-safe in-memory cache for the Shopify primary location ID in the `shopify.Client`.

🎯 Why: The location ID is required for inventory updates. If it's not configured in the database, the client fetches it via a GraphQL call to Shopify. This was happening repeatedly for every inventory sync, leading to redundant network overhead and increased latency.

📊 Impact: Reduces Shopify GraphQL API calls by 1 per inventory update (when location ID is not pre-configured). This significantly improves throughput during batch synchronization operations.

🔬 Measurement: Verify that `DiscoverPrimaryLocationID` only logs its discovery process once per application lifecycle, even across multiple inventory updates.

🔧 Additional: Fixed build errors in `MockInventoryRepository` to ensure the test suite remains green.

---
*PR created automatically by Jules for task [15159517391516581739](https://jules.google.com/task/15159517391516581739) started by @millennialperfumer-tech*