### PR TITLE
🛡️ Sentinel: [security improvement] fix insecure CORS wildcard credentials configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `CustomerRepository.List` passed the `sortBy` parameter from user input directly to GORM's `Order()` method without validation.
 **Learning:** ORM methods like GORM's `Order()` often do not parameterize identifiers (like column names) and instead concatenate them into the raw SQL query. This makes them a direct sink for SQL injection if the input is not strictly validated against an allowlist of permitted columns.
 **Prevention:** Always validate dynamic sorting parameters against a hardcoded allowlist map of valid column names before passing them to the database query layer.
+
+## 2026-03-29 - [Wildcard CORS Credential Leak]
+**Vulnerability:** `CORSMiddleware` in `backend/internal/server/middleware.go` incorrectly allowed `Access-Control-Allow-Credentials: true` even when matched against a wildcard `*` in the `ALLOWED_ORIGINS` list.
+**Learning:** Browsers strictly forbid `Access-Control-Allow-Origin: *` when `Access-Control-Allow-Credentials` is `true`. To circumvent this, the middleware was "reflecting" the request's `Origin` header even for wildcard matches. This effectively turns a wildcard into a per-request explicit allow, bypassing the security intent of the wildcard/credential restriction.
+**Prevention:** When an allowlist contains a wildcard, the logic must explicitly distinguish between an explicit domain match (where credentials can be allowed) and a wildcard match (where `Access-Control-Allow-Origin` must be `*` and `Access-Control-Allow-Credentials` must be `false`).

--- a/backend/internal/server/middleware.go
+++ b/backend/internal/server/middleware.go
@@ -27,41 +27,47 @@ func CORSMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		allowedOriginsEnv := os.Getenv("ALLOWED_ORIGINS")
 		rawOrigin := r.Header.Get("Origin")
 		origin := normalizeOrigin(rawOrigin)
-		isAllowed := false
 
 		// Always set Vary: Origin to handle caching behind proxies/CDNs
 		w.Header().Add("Vary", "Origin")
 
+		allowOrigin := ""
+		allowCredentials := false
+
 		if rawOrigin == "" {
-			// If no origin, we can consider it a direct request or same-origin
-			isAllowed = true
+			// Same-origin or direct request; no CORS headers needed
 		} else if allowedOriginsEnv != "" {
 			allowedOrigins := strings.Split(allowedOriginsEnv, ",")
 			for _, allowed := range allowedOrigins {
 				trimmed := normalizeOrigin(allowed)
-				if trimmed == "*" || origin == trimmed {
-					isAllowed = true
+				if trimmed == "*" {
+					allowOrigin = "*"
+				} else if origin == trimmed {
+					allowOrigin = rawOrigin
+					allowCredentials = true
 					break
 				}
 			}
 		}
 
-		if isAllowed {
-			if rawOrigin != "" {
-				// Use the actual origin for the allow header to support multiple origins with credentials
-				w.Header().Set("Access-Control-Allow-Origin", rawOrigin)
+		if allowOrigin != "" {
+			// Use specific origin and allow credentials only if it matched an explicit entry in the allowlist.
+			// Wildcard '*' match will use '*' and NOT allow credentials.
+			w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
+			if allowCredentials {
 				w.Header().Set("Access-Control-Allow-Credentials", "true")
-				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH")
-				w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, X-Requested-With, X-Amz-Date, X-Api-Key, X-Amz-Security-Token, X-Forwarded-For, X-Real-IP, Origin, Access-Control-Request-Method, Access-Control-Request-Headers")
-				w.Header().Set("Access-Control-Max-Age", "86400") // 24 hours
 			}
-		} else {
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH")
+			w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, X-Requested-With, X-Amz-Date, X-Api-Key, X-Amz-Security-Token, X-Forwarded-For, X-Real-IP, Origin, Access-Control-Request-Method, Access-Control-Request-Headers")
+			w.Header().Set("Access-Control-Max-Age", "86400") // 24 hours
+		} else if rawOrigin != "" {
 			log.Printf("CORS REJECTED: Origin=[%s] (normalized=[%s]) Method=[%s] Path=[%s] not in ALLOWED_ORIGINS=[%s]", 
 				rawOrigin, origin, r.Method, r.URL.Path, allowedOriginsEnv)
 		}
 
 		if r.Method == http.MethodOptions {
-			if isAllowed {
+			// Allow if it's not a CORS request or if the origin is allowed
+			if allowOrigin != "" || rawOrigin == "" {
 				w.WriteHeader(http.StatusOK)
 			} else {
 				w.WriteHeader(http.StatusForbidden)

--- a/backend/internal/server/middleware_test.go
+++ b/backend/internal/server/middleware_test.go
@@ -56,6 +56,28 @@ func TestCORSMiddleware(t *testing.T) {
 		},
 	}
 
+	t.Run("Wildcard Origin - No Credentials", func(t *testing.T) {
+		os.Setenv("ALLOWED_ORIGINS", "*")
+		defer os.Setenv("ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:5173,http://localhost:8080,https://mi-tech.millennialperfumer.in,https://feedback-form.millennialperfumer.in")
+
+		handler := CORSMiddleware(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		req := httptest.NewRequest("GET", "/api/health", nil)
+		req.Header.Set("Origin", "https://evil.com")
+		res := httptest.NewRecorder()
+
+		handler.ServeHTTP(res, req)
+
+		if res.Header().Get("Access-Control-Allow-Origin") != "*" {
+			t.Errorf("Expected Origin header '*', got %q", res.Header().Get("Access-Control-Allow-Origin"))
+		}
+		if res.Header().Get("Access-Control-Allow-Credentials") != "" {
+			t.Errorf("Expected Access-Control-Allow-Credentials to be empty for wildcard origin")
+		}
+	})
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			handler := CORSMiddleware(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] fix insecure CORS wildcard credentials configuration

💡 What:
Updated the `CORSMiddleware` in `backend/internal/server/middleware.go` to correctly distinguish between explicit domain matches and wildcard matches in the `ALLOWED_ORIGINS` environment variable.

🎯 Why:
Previously, the middleware would reflect the requester's `Origin` header and set `Access-Control-Allow-Credentials: true` even if the match was only due to a wildcard `*`. This effectively bypassed the security restriction that `*` cannot be used with credentials, allowing any third-party site to make authenticated requests to the API.

🔧 Fix:
- Refactored matching logic to track if the match was an explicit domain or a wildcard.
- If an explicit domain matches: `Access-Control-Allow-Origin: [origin]` and `Access-Control-Allow-Credentials: true`.
- If only wildcard matches: `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Credentials` is omitted.
- Handled `OPTIONS` preflight requests to respect this logic.

✅ Verification:
- Added a specific test case `Wildcard Origin - No Credentials` to `backend/internal/server/middleware_test.go`.
- Verified that existing CORS tests still pass.
- Ran `go vet` and `go test` in the server package.

🚨 Severity: HIGH (Auth Bypass/CSRF vulnerability)

---
*PR created automatically by Jules for task [6561697917250145920](https://jules.google.com/task/6561697917250145920) started by @millennialperfumer-tech*