### PR TITLE
🛡️ Sentinel: [security improvement] Harden sensitive comparisons against timing attacks

### DIFF
--- a/backend/internal/handler/marketing_webhook_handler.go
+++ b/backend/internal/handler/marketing_webhook_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"mi-tech/internal/config"
 	"mi-tech/internal/marketing"
@@ -43,7 +44,7 @@ func (h *MarketingWebhookHandler) verifyWebhook(w http.ResponseWriter, r *http.R
 
 	expectedToken := h.settings.GetMetaMarketingWebhookVerifyToken()
 
-	if mode == "subscribe" && token == expectedToken {
+	if mode == "subscribe" && subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1 {
 		fmt.Printf("Meta Marketing Webhook verified successfully!\n")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(challenge))

--- a/backend/internal/handler/webhook_handler.go
+++ b/backend/internal/handler/webhook_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -270,7 +271,7 @@ func (h *WebhookHandler) verifyWebhook(r *http.Request, body []byte) bool {
 	hash.Write(body)
 	expectedHmac := base64.StdEncoding.EncodeToString(hash.Sum(nil))
 
-	isMatch := hmacHeader == expectedHmac
+	isMatch := subtle.ConstantTimeCompare([]byte(hmacHeader), []byte(expectedHmac)) == 1
 	if !isMatch {
 		log.Printf("Webhook HMAC Mismatch!")
 		log.Printf("  Received: %s", hmacHeader)

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"mi-tech/internal/config"
@@ -126,7 +127,7 @@ func (s *AuthService) VerifyOTP(username, otp string) (string, error) {
 		return "", errors.New("verification code expired or not found")
 	}
 
-	if user.OTPCode != otp {
+	if subtle.ConstantTimeCompare([]byte(user.OTPCode), []byte(otp)) != 1 {
 		return "", errors.New("invalid verification code")
 	}
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Non-constant-time string comparisons for OTP codes, webhook tokens, and HMAC signatures.
🎯 Impact: Attackers could potentially use timing side-channel attacks to brute-force secrets character-by-character.
🔧 Fix: Replaced standard string equality checks with `subtle.ConstantTimeCompare` in `auth_service.go`, `marketing_webhook_handler.go`, and `webhook_handler.go`.
✅ Verification: Verified with `auth_service_test.go` and verified that handlers build successfully.

---
*PR created automatically by Jules for task [2547418454272487904](https://jules.google.com/task/2547418454272487904) started by @millennialperfumer-tech*