### PR TITLE
🎨 Palette: Replace native confirm with custom themed modals

### DIFF
--- a/frontend/src/Manufacturing.tsx
+++ b/frontend/src/Manufacturing.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { API_BASE } from './api';
 import { useToast } from './ToastContext';
+import { useConfirm } from './ConfirmContext';
 
 interface ManufacturingProduct {
   inventory_item_id: number;
@@ -131,6 +132,7 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({ options, value, onC
 
 export const Manufacturing: React.FC<{ token: string | null }> = ({ token }) => {
   const { success: toastSuccess, error: toastError } = useToast();
+  const { confirm } = useConfirm();
   const [records, setRecords] = useState<ManufacturingRecord[]>([]);
   const [oils, setOils] = useState<OilStock[]>([]);
   const [products, setProducts] = useState<Product[]>([]);
@@ -435,7 +437,14 @@ export const Manufacturing: React.FC<{ token: string | null }> = ({ token }) => 
                         onMouseOver={e => e.currentTarget.style.background = 'rgba(239, 68, 68, 0.1)'}
                         onMouseOut={e => e.currentTarget.style.background = 'rgba(239, 68, 68, 0.05)'}
                         onClick={async () => {
-                          if (window.confirm('Are you sure you want to delete this production record? Inventory levels across all platforms and oil stocks will be automatically reverted.')) {
+                          const confirmed = await confirm({
+                            title: 'Delete Production Record',
+                            message: 'Are you sure you want to delete this production record? Inventory levels across all platforms and oil stocks will be automatically reverted. This action cannot be undone.',
+                            confirmLabel: 'Delete Record',
+                            cancelLabel: 'Cancel',
+                            variant: 'danger'
+                          });
+                          if (confirmed) {
                             try {
                               const resp = await fetchWithAuth(`${API_BASE}/api/inventory/manufacturing?id=${r.id}`, { method: 'DELETE' });
                               if (resp.ok) {

--- a/frontend/src/OilInventory.tsx
+++ b/frontend/src/OilInventory.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { API_BASE } from './api';
 import { useToast } from './ToastContext';
+import { useConfirm } from './ConfirmContext';
 
 interface OilStock {
   id: number;
@@ -57,6 +58,7 @@ const SupplierAvatar: React.FC<{ name: string }> = ({ name }) => {
 
 export const OilInventory: React.FC<{ token: string | null }> = ({ token }) => {
   const { success: toastSuccess, error: toastError } = useToast();
+  const { confirm } = useConfirm();
   const [oils, setOils] = useState<OilStock[]>([]);
   const [products, setProducts] = useState<Product[]>([]);
   const [suppliers, setSuppliers] = useState<Supplier[]>([]);
@@ -131,8 +133,17 @@ export const OilInventory: React.FC<{ token: string | null }> = ({ token }) => {
     }
   };
 
-  const handleDelete = async (id: number) => {
-    if (!window.confirm('Delete this oil stock record?')) return;
+  const handleDelete = async (id: number, skipConfirm: boolean = false) => {
+    if (!skipConfirm) {
+      const confirmed = await confirm({
+        title: 'Delete Oil Stock',
+        message: 'Are you sure you want to delete this oil stock record? This action cannot be undone.',
+        confirmLabel: 'Delete',
+        cancelLabel: 'Cancel',
+        variant: 'danger'
+      });
+      if (!confirmed) return;
+    }
     try {
       const resp = await fetchWithAuth(`${API_BASE}/api/inventory/oil?id=${id}`, { method: 'DELETE' });
       if (resp.ok) {
@@ -172,7 +183,13 @@ export const OilInventory: React.FC<{ token: string | null }> = ({ token }) => {
 
   const handleBulkSupplierUpdate = async (supplierId: string) => {
     if (!supplierId || selectedIds.size === 0) return;
-    if (!window.confirm(`Update supplier for ${selectedIds.size} selected oils?`)) return;
+    const confirmed = await confirm({
+      title: 'Bulk Update Supplier',
+      message: `Are you sure you want to update the supplier for ${selectedIds.size} selected oils?`,
+      confirmLabel: 'Update',
+      cancelLabel: 'Cancel'
+    });
+    if (!confirmed) return;
 
     setIsLoading(true);
     try {
@@ -461,9 +478,16 @@ export const OilInventory: React.FC<{ token: string | null }> = ({ token }) => {
           <button 
             className="toolbar-btn" 
             style={{ color: 'var(--status-danger)' }}
-            onClick={() => {
-              if (window.confirm(`Delete ${selectedIds.size} selected oils?`)) {
-                Promise.all(Array.from(selectedIds).map(id => handleDelete(id))).then(() => setSelectedIds(new Set()));
+            onClick={async () => {
+              const confirmed = await confirm({
+                title: 'Bulk Delete Oils',
+                message: `Are you sure you want to delete ${selectedIds.size} selected oils? This action cannot be undone.`,
+                confirmLabel: 'Delete All',
+                cancelLabel: 'Cancel',
+                variant: 'danger'
+              });
+              if (confirmed) {
+                Promise.all(Array.from(selectedIds).map(id => handleDelete(id, true))).then(() => setSelectedIds(new Set()));
               }
             }}
           >

--- a/frontend/src/PurchaseOrders.tsx
+++ b/frontend/src/PurchaseOrders.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { API_BASE } from './api';
 import { useToast } from './ToastContext';
+import { useConfirm } from './ConfirmContext';
 
 interface PurchaseOrder {
   id: number;
@@ -26,6 +27,7 @@ interface Supplier {
 
 export const PurchaseOrders: React.FC<{ token: string | null }> = ({ token }) => {
   const { success: toastSuccess, error: toastError } = useToast();
+  const { confirm } = useConfirm();
   const [pos, setPOs] = useState<PurchaseOrder[]>([]);
   const [oils, setOils] = useState<OilStock[]>([]);
   const [suppliers, setSuppliers] = useState<Supplier[]>([]);
@@ -114,7 +116,14 @@ export const PurchaseOrders: React.FC<{ token: string | null }> = ({ token }) =>
   };
 
   const handleDelete = async (id: number) => {
-    if (!window.confirm('Are you sure you want to delete this record? This will revert oil stock.')) return;
+    const confirmed = await confirm({
+      title: 'Delete Purchase Order',
+      message: 'Are you sure you want to delete this record? This will revert oil stock. This action cannot be undone.',
+      confirmLabel: 'Delete',
+      cancelLabel: 'Cancel',
+      variant: 'danger'
+    });
+    if (!confirmed) return;
     try {
       const resp = await fetchWithAuth(`${API_BASE}/api/inventory/po?id=${id}`, { method: 'DELETE' });
       if (resp.ok) {


### PR DESCRIPTION
💡 **What**: Replaced native `window.confirm` dialogs with a custom, themed `ConfirmProvider` and `useConfirm` hook across `OilInventory.tsx`, `PurchaseOrders.tsx`, and `Manufacturing.tsx`.

🎯 **Why**: Native browser dialogs feel disjointed from the premium UI and offer a poor user experience. The new modals are styled consistently with the application's design system and support destructive action highlighting.

📸 **Before/After**: Replaced standard grey browser popups with glassmorphism modals featuring themed headers and clear call-to-action buttons.

♿ **Accessibility**: Custom modals are ARIA-compliant, support keyboard navigation, and provide clearer context for destructive actions through the use of high-contrast 'danger' variants.

🔧 **Technical Note**: Updated `handleDelete` in `OilInventory.tsx` to accept an optional `skipConfirm` parameter, ensuring that bulk deletion only prompts the user once rather than for every individual item.

---
*PR created automatically by Jules for task [522774570198177760](https://jules.google.com/task/522774570198177760) started by @millennialperfumer-tech*