### PR TITLE
🛡️ Sentinel: [security improvement] Harden OTP verification against timing attacks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `CustomerRepository.List` passed the `sortBy` parameter from user input directly to GORM's `Order()` method without validation.
 **Learning:** ORM methods like GORM's `Order()` often do not parameterize identifiers (like column names) and instead concatenate them into the raw SQL query. This makes them a direct sink for SQL injection if the input is not strictly validated against an allowlist of permitted columns.
 **Prevention:** Always validate dynamic sorting parameters against a hardcoded allowlist map of valid column names before passing them to the database query layer.
+
+## 2025-05-20 - [Timing Attack in OTP Verification]
+**Vulnerability:** `AuthService.VerifyOTP` used standard string comparison (`!=`) for 6-digit OTP verification.
+**Learning:** Standard string comparisons in many languages (including Go) exit early as soon as a mismatch is found. In the context of a short, numeric OTP, an attacker can measure these micro-differences in response time to brute-force the code character-by-character, significantly reducing the effective entropy.
+**Prevention:** Use `crypto/subtle.ConstantTimeCompare` for all sensitive credential comparisons, including OTPs, API keys, and signatures.

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"crypto/rand"
+	"crypto/subtle"
 	"io"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -126,7 +127,7 @@ func (s *AuthService) VerifyOTP(username, otp string) (string, error) {
 		return "", errors.New("verification code expired or not found")
 	}
 
-	if user.OTPCode != otp {
+	if subtle.ConstantTimeCompare([]byte(user.OTPCode), []byte(otp)) != 1 {
 		return "", errors.New("invalid verification code")
 	}
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Timing side-channel attack in OTP verification.
🎯 Impact: An attacker could potentially brute-force the 6-digit OTP character-by-character by measuring response times.
🔧 Fix: Used `crypto/subtle.ConstantTimeCompare` for constant-time comparison of OTP codes.
✅ Verification: Code builds and passes existing tests; security enhancement verified by code review.

---
*PR created automatically by Jules for task [4505248486920012196](https://jules.google.com/task/4505248486920012196) started by @millennialperfumer-tech*