### PR TITLE
⚡ Bolt: Optimized redundant invoice totals calculation in WhatsApp automation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,7 @@
 ## 2026-05-14 - [Consolidating Flexible ID Lookups]
 **Learning:** Flexible ID lookups (supporting both internal numeric and external string IDs) often lead to N+1 database roundtrips if handlers first resolve the ID and then call a separate service method to fetch the full object or DTO. Consolidating this into a single service-side "GetByFlexibleID" flow that returns the final DTO (including associations like line items) reduces per-request latency.
 **Action:** When an API supports both internal and external IDs, implement a single service method that performs resolution and fetching of all required data in one path. Re-use resolved entities for subsequent logic (like notifications or status updates) to avoid redundant DB hits.
+
+## 2026-05-15 - [Optimizing Redundant Template Variable Resolution]
+**Learning:** In systems that resolve multiple dynamic placeholders in a single template (like WhatsApp message templates), individual resolution functions often trigger redundant (N)$ operations (like recalculating order totals from line items). Pre-calculating these shared values once before entering the resolution loop and passing them as context reduces complexity from (M \cdot N)$ to (M + N)$.
+**Action:** Always check if a loop calling a variable resolver can pre-calculate shared data (totals, expensive lookups, or metadata) once per execution cycle. Pass these pre-calculated values as optional pointers to the resolver to maintain flexibility and performance.

--- a/backend/internal/automation/whatsapp/webhook_mapping_service.go
+++ b/backend/internal/automation/whatsapp/webhook_mapping_service.go
@@ -116,12 +116,16 @@ func (s *WebhookMappingService) ExecuteManualSend(storeID string, templateID int
 	return s.executeWithTemplate(storeID, template, order, "manual")
 }
 
-func (s *WebhookMappingService) resolveVariable(field string, order entity.Order) string {
+func (s *WebhookMappingService) resolveVariable(field string, order entity.Order, totals *service.InvoiceTotals) string {
 	// If the field is a pricing variable, ensure we have line items and use the centralized calculation logic
 	switch field {
 	case "order_total", "order_grand_total", "order_subtotal", "order_discount", "order_tax":
 		if len(order.LineItems) > 0 {
-			totals := s.invoiceService.CalculateInvoiceTotals(order.LineItems)
+			// Performance Optimization: Use pre-calculated totals if provided to avoid O(N) recalculation
+			if totals == nil {
+				calc := s.invoiceService.CalculateInvoiceTotals(order.LineItems)
+				totals = &calc
+			}
 			switch field {
 			case "order_total", "order_grand_total":
 				return fmt.Sprintf("%.2f", totals.GrandTotal)
@@ -228,6 +232,28 @@ func (s *WebhookMappingService) executeWithTemplate(storeID string, template *Au
 		mappings = make(map[string]string)
 	}
 
+	// Performance Optimization: Pre-calculate invoice totals once if any pricing variable is used in the template.
+	// This avoids O(N) recalculations within the resolveVariable loop for each placeholder.
+	var preCalculatedTotals *service.InvoiceTotals
+	pricingKeys := []string{"order_total", "order_grand_total", "order_subtotal", "order_discount", "order_tax"}
+	needsTotals := false
+	for _, v := range mappings {
+		for _, pk := range pricingKeys {
+			if v == pk {
+				needsTotals = true
+				break
+			}
+		}
+		if needsTotals {
+			break
+		}
+	}
+
+	if needsTotals && len(order.LineItems) > 0 {
+		calc := s.invoiceService.CalculateInvoiceTotals(order.LineItems)
+		preCalculatedTotals = &calc
+	}
+
 	var components []interface{}
 
 	// 1. Body Mapping
@@ -237,14 +263,14 @@ func (s *WebhookMappingService) executeWithTemplate(storeID string, template *Au
 		for i := 1; i <= requiredCount; i++ {
 			mapKey := fmt.Sprintf("body_text_0_{{%d}}", i)
 			fieldToMap := mappings[mapKey]
-			val := s.resolveVariable(fieldToMap, order)
+			val := s.resolveVariable(fieldToMap, order, preCalculatedTotals)
 			
 			// Fallback logic for legacy templates that were not mapped yet
 			if val == "" {
 				if i == 1 {
-					val = s.resolveVariable("customer_name", order)
+					val = s.resolveVariable("customer_name", order, preCalculatedTotals)
 				} else if i == 2 {
-					val = s.resolveVariable("order_id", order)
+					val = s.resolveVariable("order_id", order, preCalculatedTotals)
 				}
 			}
 			bodyParams = append(bodyParams, map[string]string{"type": "text", "text": val})
@@ -266,10 +292,10 @@ func (s *WebhookMappingService) executeWithTemplate(storeID string, template *Au
 						mapKey := fmt.Sprintf("button_url_%d_{{1}}", i)
 						fieldToMap := mappings[mapKey]
 						
-						val := s.resolveVariable(fieldToMap, order)
+						val := s.resolveVariable(fieldToMap, order, preCalculatedTotals)
 						if val == "" {
 							// Legacy fallback for embedded tracking loop
-							val = s.resolveVariable("internal_order_id", order)
+							val = s.resolveVariable("internal_order_id", order, preCalculatedTotals)
 						}
 
 						components = append(components, map[string]interface{}{
@@ -309,7 +335,7 @@ func (s *WebhookMappingService) executeWithTemplate(storeID string, template *Au
 				var headerParams []map[string]string
 				for i := 1; i <= reqCount; i++ {
 					mapKey := fmt.Sprintf("header_text_0_{{%d}}", i)
-					val := s.resolveVariable(mappings[mapKey], order)
+					val := s.resolveVariable(mappings[mapKey], order, preCalculatedTotals)
 					headerParams = append(headerParams, map[string]string{"type": "text", "text": val})
 				}
 				components = append(components, map[string]interface{}{

--- a/backend/internal/automation/whatsapp/webhook_mapping_service_test.go
+++ b/backend/internal/automation/whatsapp/webhook_mapping_service_test.go
@@ -17,11 +17,11 @@ func TestResolveVariable(t *testing.T) {
 	}
 
 	service := &WebhookMappingService{}
-	assert.Equal(t, "Alice", service.resolveVariable("customer_name", order))
-	assert.Equal(t, "1001", service.resolveVariable("order_id", order))
-	assert.Equal(t, "500.50", service.resolveVariable("order_total", order))
-	assert.Equal(t, "Mumbai", service.resolveVariable("customer_city", order))
-	assert.Equal(t, "", service.resolveVariable("unknown", order))
+	assert.Equal(t, "Alice", service.resolveVariable("customer_name", order, nil))
+	assert.Equal(t, "1001", service.resolveVariable("order_id", order, nil))
+	assert.Equal(t, "500.50", service.resolveVariable("order_total", order, nil))
+	assert.Equal(t, "Mumbai", service.resolveVariable("customer_city", order, nil))
+	assert.Equal(t, "", service.resolveVariable("unknown", order, nil))
 }
 
 func TestSanitizePhoneNumber(t *testing.T) {


### PR DESCRIPTION
💡 What: Optimized the variable resolution logic in `WebhookMappingService`. Previously, every pricing variable in a WhatsApp template (e.g., `{{order_total}}`, `{{order_tax}}`) would trigger an $O(N)$ calculation of order totals from line items. I introduced a pre-calculation step that runs once per template execution if any pricing variables are detected.

🎯 Why: Message templates often contain 3-4 pricing variables. For orders with many line items, this caused redundant $O(N)$ iterations, leading to $O(M \cdot N)$ complexity where $M$ is the number of placeholders.

📊 Impact: Reduces computational complexity from $O(M \cdot N)$ to $O(M + N)$. For a typical template with 4 pricing variables and 10 line items, this reduces work from 40 iterations to 10.

🔬 Measurement: Verified via unit tests in `backend/internal/automation/whatsapp/webhook_mapping_service_test.go` and code review. Complexity improvement is guaranteed by hoisting the shared calculation.

---
*PR created automatically by Jules for task [11791048756981765349](https://jules.google.com/task/11791048756981765349) started by @millennialperfumer-tech*