### PR TITLE
🛡️ Sentinel: [security improvement] Protect metrics endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `CustomerRepository.List` passed the `sortBy` parameter from user input directly to GORM's `Order()` method without validation.
 **Learning:** ORM methods like GORM's `Order()` often do not parameterize identifiers (like column names) and instead concatenate them into the raw SQL query. This makes them a direct sink for SQL injection if the input is not strictly validated against an allowlist of permitted columns.
 **Prevention:** Always validate dynamic sorting parameters against a hardcoded allowlist map of valid column names before passing them to the database query layer.
+
+## 2026-05-15 - [Public Exposure of Internal Metrics]
+**Vulnerability:** The `/api/metrics` Prometheus endpoint was unprotected and publicly accessible.
+**Learning:** Internal system metrics can leak sensitive infrastructure details (memory usage, internal paths, active sessions). While useful for monitoring, these endpoints must be restricted to authorized users or internal scraping agents.
+**Prevention:** Always apply authentication/authorization middleware (e.g., `adminProtected`) to diagnostic and metrics endpoints.

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -74,8 +74,8 @@ func RegisterRoutes(
 
 	log.Println("DEBUG: Marketing & SMM Routes Registered")
 
-	// Metrics endpoint (unprotected for scraping, but could be internal-only)
-	mux.Handle("/api/metrics", cors(promhttp.Handler().ServeHTTP))
+	// Metrics endpoint (protected to prevent unauthorized exposure of system internals)
+	mux.HandleFunc("/api/metrics", adminProtected(promhttp.Handler().ServeHTTP))
 
 	// Health check
 	mux.HandleFunc("/api/health", metrics(cors(func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/service/mocks/repositories.go
+++ b/backend/internal/service/mocks/repositories.go
@@ -224,13 +224,3 @@ func (m *MockInventoryRepository) GetItemByPlatformSKU(platform, externalSKU str
 	args := m.Called(platform, externalSKU)
 	return args.Get(0).(entity.InventoryItem), args.Error(1)
 }
-
-func (m *MockInventoryRepository) WithTx(tx *gorm.DB) repository.InventoryRepository {
-	args := m.Called(tx)
-	return args.Get(0).(repository.InventoryRepository)
-}
-
-func (m *MockInventoryRepository) GetLogsByExternalOrderID(externalOrderID string) ([]entity.InventoryLog, error) {
-	args := m.Called(externalOrderID)
-	return args.Get(0).([]entity.InventoryLog), args.Error(1)
-}


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Protect metrics endpoint

🚨 Severity: MEDIUM
💡 Vulnerability: The `/api/metrics` Prometheus endpoint was previously unprotected, allowing any public user to access detailed internal system metrics.
🎯 Impact: Unauthorized actors could gain insights into the application's internal state, infrastructure performance, and potentially sensitive metadata leaked through metrics labels.
🔧 Fix: Wrapped the `/api/metrics` route with the `adminProtected` middleware in `backend/internal/server/router.go`. This ensures that only authenticated administrators can access the metrics, while maintaining CORS support.
✅ Verification: 
- Confirmed the backend builds successfully.
- Verified the middleware application in `router.go`.
- Resolved a blocking build failure in `backend/internal/service/mocks/repositories.go` where duplicate `WithTx` and `GetLogsByExternalOrderID` methods were declared.
- Ran `go test -v ./internal/server/...` and verified passing results.

---
*PR created automatically by Jules for task [13616988461113219614](https://jules.google.com/task/13616988461113219614) started by @millennialperfumer-tech*