### PR TITLE
🛡️ Sentinel: [HIGH] Fix CORS wildcard credentials bypass

### DIFF
--- a/backend/internal/server/middleware.go
+++ b/backend/internal/server/middleware.go
@@ -48,9 +48,15 @@ func CORSMiddleware(next http.HandlerFunc) http.HandlerFunc {
 
 		if isAllowed {
 			if rawOrigin != "" {
-				// Use the actual origin for the allow header to support multiple origins with credentials
-				w.Header().Set("Access-Control-Allow-Origin", rawOrigin)
-				w.Header().Set("Access-Control-Allow-Credentials", "true")
+				// Security: If allowed via wildcard, do NOT set Allow-Credentials: true
+				// and set Allow-Origin to '*' instead of reflecting the origin.
+				if allowedOriginsEnv == "*" {
+					w.Header().Set("Access-Control-Allow-Origin", "*")
+				} else {
+					// Use the actual origin for the allow header to support multiple origins with credentials
+					w.Header().Set("Access-Control-Allow-Origin", rawOrigin)
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
+				}
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH")
 				w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, X-Requested-With, X-Amz-Date, X-Api-Key, X-Amz-Security-Token, X-Forwarded-For, X-Real-IP, Origin, Access-Control-Request-Method, Access-Control-Request-Headers")
 				w.Header().Set("Access-Control-Max-Age", "86400") // 24 hours

--- a/backend/internal/server/middleware_test.go
+++ b/backend/internal/server/middleware_test.go
@@ -84,3 +84,30 @@ func TestCORSMiddleware(t *testing.T) {
 		})
 	}
 }
+
+func TestCORSMiddlewareWildcard(t *testing.T) {
+	os.Setenv("ALLOWED_ORIGINS", "*")
+	defer os.Unsetenv("ALLOWED_ORIGINS")
+
+	handler := CORSMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/api/health", nil)
+	req.Header.Set("Origin", "http://evil.com")
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	// Currently, it reflects the origin and allows credentials - this is the vulnerability
+	originHeader := res.Header().Get("Access-Control-Allow-Origin")
+	credsHeader := res.Header().Get("Access-Control-Allow-Credentials")
+
+	// Verify it meets our NEW desired state (Security Enhancement)
+	if originHeader != "*" {
+		t.Errorf("Expected Origin header '*', got %q", originHeader)
+	}
+	if credsHeader != "" {
+		t.Errorf("Expected empty Access-Control-Allow-Credentials, got %q", credsHeader)
+	}
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: When `ALLOWED_ORIGINS` was set to `*`, the `CORSMiddleware` reflected the requester's `Origin` header and set `Access-Control-Allow-Credentials: true`.
🎯 Impact: This allows any third-party website to make authenticated requests to the API on behalf of a user, bypassing CORS protections and potentially leading to CSRF-like data theft.
🔧 Fix: Hardened `CORSMiddleware` to return a literal `*` for the `Access-Control-Allow-Origin` header and omit `Access-Control-Allow-Credentials` when a wildcard is configured.
✅ Verification: Added `TestCORSMiddlewareWildcard` in `middleware_test.go` to verify the fix. Existing tests pass.

---
*PR created automatically by Jules for task [6451432284940043092](https://jules.google.com/task/6451432284940043092) started by @millennialperfumer-tech*