### PR TITLE
⚡ Bolt: optimize oil inventory bulk delete to O(1) requests

### DIFF
--- a/backend/internal/handler/oil_inventory_handler.go
+++ b/backend/internal/handler/oil_inventory_handler.go
@@ -68,3 +68,20 @@ func (h *OilInventoryHandler) DeleteOil(w http.ResponseWriter, r *http.Request) 
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
+
+func (h *OilInventoryHandler) BulkDeleteOils(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		IDs []int `json:"ids"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.service.BulkDeleteOils(req.IDs); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -206,6 +206,7 @@ type OilInventoryRepository interface {
 	Create(item *entity.OilInventory) error
 	Update(item *entity.OilInventory) error
 	Delete(id int) error
+	BulkDelete(ids []int) error
 }
 
 // SupplierRepository defines all data access for vendors.

--- a/backend/internal/repository/oil_inventory_repository.go
+++ b/backend/internal/repository/oil_inventory_repository.go
@@ -48,3 +48,10 @@ func (r *pgOilInventoryRepository) Update(item *entity.OilInventory) error {
 func (r *pgOilInventoryRepository) Delete(id int) error {
 	return r.db.Delete(&entity.OilInventory{}, id).Error
 }
+
+func (r *pgOilInventoryRepository) BulkDelete(ids []int) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	return r.db.Delete(&entity.OilInventory{}, ids).Error
+}

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -324,6 +324,7 @@ func RegisterRoutes(
 	mux.HandleFunc("/api/inventory/item", adminProtected(inventoryHandler.UpdateItem))
 	
 	// --- Oil Inventory Routes ---
+	mux.HandleFunc("/api/inventory/oil/bulk-delete", adminProtected(oilHandler.BulkDeleteOils))
 	mux.HandleFunc("/api/inventory/oil", protected(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodPost:

--- a/backend/internal/service/oil_inventory_service.go
+++ b/backend/internal/service/oil_inventory_service.go
@@ -32,3 +32,7 @@ func (s *OilInventoryService) UpdateOil(item *entity.OilInventory) error {
 func (s *OilInventoryService) DeleteOil(id int) error {
 	return s.repo.Delete(id)
 }
+
+func (s *OilInventoryService) BulkDeleteOils(ids []int) error {
+	return s.repo.BulkDelete(ids)
+}

--- a/frontend/src/OilInventory.tsx
+++ b/frontend/src/OilInventory.tsx
@@ -521,29 +521,34 @@ export const OilInventory: React.FC<{ token: string | null }> = ({ token }) => {
           <button 
             className="toolbar-btn" 
             style={{ color: 'var(--status-danger)' }}
+            disabled={isLoading}
             onClick={async () => {
+              const count = selectedIds.size;
               const confirmed = await confirm({
                 title: 'Bulk Delete Oils',
-                message: `Are you sure you want to delete ${selectedIds.size} selected oils? This action cannot be undone.`,
+                message: `Are you sure you want to delete ${count} selected oils? This action cannot be undone.`,
                 confirmLabel: 'Delete All',
                 variant: 'danger'
               });
               if (confirmed) {
-                // handleDelete already has its own confirmation, so we should skip it or use a different approach
-                // for bulk. But here it calls handleDelete(id) which will prompt for EACH one if not careful.
-                // Wait, handleDelete in OilInventory.tsx prompts.
-                // I should probably refactor handleDelete to accept a skipConfirm param or just do the logic here.
-
+                setIsLoading(true);
                 try {
-                  await Promise.all(Array.from(selectedIds).map(async (id) => {
-                    const resp = await fetchWithAuth(`${API_BASE}/api/inventory/oil?id=${id}`, { method: 'DELETE' });
-                    return resp.ok;
-                  }));
-                  toastSuccess(`${selectedIds.size} oil records deleted`);
-                  setSelectedIds(new Set());
-                  fetchData();
+                  const resp = await fetchWithAuth(`${API_BASE}/api/inventory/oil/bulk-delete`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ ids: Array.from(selectedIds) })
+                  });
+                  if (resp.ok) {
+                    toastSuccess(`${count} oil records deleted`);
+                    setSelectedIds(new Set());
+                    fetchData();
+                  } else {
+                    toastError('Failed to delete oils in bulk');
+                  }
                 } catch (err) {
                   toastError('Error during bulk deletion');
+                } finally {
+                  setIsLoading(false);
                 }
               }
             }}


### PR DESCRIPTION
Optimized the Oil Inventory bulk delete process by introducing a backend bulk delete endpoint. This change reduces the number of network requests and database transactions from O(N) to O(1), significantly improving performance and efficiency for bulk operations.

---
*PR created automatically by Jules for task [12839544858832121755](https://jules.google.com/task/12839544858832121755) started by @millennialperfumer-tech*