### PR TITLE
⚡ Bolt: Optimize PurchaseOrder BulkCreate

### DIFF
--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -221,9 +221,11 @@ type SupplierRepository interface {
 
 // PurchaseOrderRepository defines all data access for raw material purchases.
 type PurchaseOrderRepository interface {
+	WithTx(tx *gorm.DB) PurchaseOrderRepository
 	List() ([]entity.PurchaseOrder, error)
 	GetByID(id int) (*entity.PurchaseOrder, error)
 	Create(po *entity.PurchaseOrder) error
+	BulkCreate(pos []entity.PurchaseOrder) error
 	Update(po *entity.PurchaseOrder) error
 	Delete(id int) error
 }

--- a/backend/internal/repository/purchase_order_repository.go
+++ b/backend/internal/repository/purchase_order_repository.go
@@ -13,6 +13,13 @@ func NewPurchaseOrderRepository(db *gorm.DB) PurchaseOrderRepository {
 	return &pgPurchaseOrderRepository{db: db}
 }
 
+func (r *pgPurchaseOrderRepository) WithTx(tx *gorm.DB) PurchaseOrderRepository {
+	if tx == nil {
+		return r
+	}
+	return &pgPurchaseOrderRepository{db: tx}
+}
+
 func (r *pgPurchaseOrderRepository) List() ([]entity.PurchaseOrder, error) {
 	var pos []entity.PurchaseOrder
 	err := r.db.Preload("OilInventory").Preload("Supplier").Order("purchase_date desc").Find(&pos).Error
@@ -27,6 +34,13 @@ func (r *pgPurchaseOrderRepository) GetByID(id int) (*entity.PurchaseOrder, erro
 
 func (r *pgPurchaseOrderRepository) Create(po *entity.PurchaseOrder) error {
 	return r.db.Create(po).Error
+}
+
+func (r *pgPurchaseOrderRepository) BulkCreate(pos []entity.PurchaseOrder) error {
+	if len(pos) == 0 {
+		return nil
+	}
+	return r.db.Create(&pos).Error
 }
 
 func (r *pgPurchaseOrderRepository) Update(po *entity.PurchaseOrder) error {

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -90,7 +90,7 @@ func NewServer(cfg *config.Config, db *gorm.DB) *Server {
 	inventoryService := service.NewInventoryService(inventoryRepo, shopifyClient, syncOrchestrator, settingsProvider, amazonOrderPoller)
 	oilService := service.NewOilInventoryService(oilRepo)
 	supplierService := service.NewSupplierService(supplierRepo)
-	poService := service.NewPurchaseOrderService(poRepo, oilRepo)
+	poService := service.NewPurchaseOrderService(db, poRepo, oilRepo)
 	mfgService := service.NewManufacturingService(db, mfgRepo, oilRepo, syncOrchestrator)
 	whatsappService := whatsapp.NewTemplatesService(whatsappRepo, settingsProvider)
 	notifService := whatsapp.NewNotificationService(settingsProvider)

--- a/backend/internal/service/purchase_order_service.go
+++ b/backend/internal/service/purchase_order_service.go
@@ -5,15 +5,18 @@ import (
 	"time"
 	"mi-tech/internal/entity"
 	"mi-tech/internal/repository"
+	"gorm.io/gorm"
 )
 
 type PurchaseOrderService struct {
+	db      *gorm.DB
 	poRepo  repository.PurchaseOrderRepository
 	oilRepo repository.OilInventoryRepository
 }
 
-func NewPurchaseOrderService(poRepo repository.PurchaseOrderRepository, oilRepo repository.OilInventoryRepository) *PurchaseOrderService {
+func NewPurchaseOrderService(db *gorm.DB, poRepo repository.PurchaseOrderRepository, oilRepo repository.OilInventoryRepository) *PurchaseOrderService {
 	return &PurchaseOrderService{
+		db:      db,
 		poRepo:  poRepo,
 		oilRepo: oilRepo,
 	}
@@ -57,13 +60,70 @@ func (s *PurchaseOrderService) Create(po *entity.PurchaseOrder) error {
 	return s.oilRepo.Update(&oil)
 }
 
+// BulkCreate handles multiple purchase orders in a single optimized transaction.
+// Optimization: Batch inserts POs and aggregates oil stock updates to eliminate N+1 queries.
+// Expected Impact: Reduces database roundtrips from O(3N) to O(M+1) (where M is unique oils).
 func (s *PurchaseOrderService) BulkCreate(pos []entity.PurchaseOrder) error {
-	for i := range pos {
-		if err := s.Create(&pos[i]); err != nil {
+	if len(pos) == 0 {
+		return nil
+	}
+
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		now := time.Now()
+		for i := range pos {
+			if pos[i].PurchaseDate.IsZero() {
+				pos[i].PurchaseDate = now
+			}
+		}
+
+		// 1. Batch Create POs in a single roundtrip
+		if err := s.poRepo.WithTx(tx).BulkCreate(pos); err != nil {
 			return err
 		}
-	}
-	return nil
+
+		// 2. Aggregate Stock Adjustments and Metadata per Oil
+		type oilUpdate struct {
+			Delta          float64
+			LatestPrice    float64
+			LatestSupplier int
+			LatestDate     time.Time
+		}
+		oilUpdates := make(map[int]*oilUpdate)
+
+		for i := range pos {
+			po := &pos[i]
+			update, exists := oilUpdates[po.OilInventoryID]
+			if !exists {
+				update = &oilUpdate{}
+				oilUpdates[po.OilInventoryID] = update
+			}
+
+			update.Delta += po.QuantityGrams
+			// Track latest metadata to update the oil record
+			if po.PurchaseDate.After(update.LatestDate) || update.LatestDate.IsZero() {
+				update.LatestDate = po.PurchaseDate
+				update.LatestPrice = po.UnitPricePerKg
+				update.LatestSupplier = po.SupplierID
+			}
+		}
+
+		// 3. Apply aggregated updates to Oil Inventory
+		for oilID, upd := range oilUpdates {
+			// Atomic stock update + metadata update in one query per oil
+			if err := tx.Model(&entity.OilInventory{}).
+				Where("id = ?", oilID).
+				Updates(map[string]interface{}{
+					"grams_left":            gorm.Expr("COALESCE(grams_left, 0) + ?", upd.Delta),
+					"purchase_price_per_kg": upd.LatestPrice,
+					"supplier_id":           upd.LatestSupplier,
+					"updated_at":            now,
+				}).Error; err != nil {
+				return fmt.Errorf("failed to update oil stock and metadata for ID %d: %w", oilID, err)
+			}
+		}
+
+		return nil
+	})
 }
 
 func (s *PurchaseOrderService) Update(po *entity.PurchaseOrder) error {

--- a/backend/internal/service/purchase_order_service_test.go
+++ b/backend/internal/service/purchase_order_service_test.go
@@ -1,0 +1,129 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"mi-tech/internal/entity"
+	"mi-tech/internal/repository"
+	"mi-tech/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPurchaseOrderService_BulkCreate(t *testing.T) {
+	db, err := testutil.SetupTestDB()
+	if err != nil {
+		t.Skip("DB not available")
+	}
+	defer testutil.CleanupTestDB(db)
+
+	// 0. Setup dependencies
+	poRepo := repository.NewPurchaseOrderRepository(db)
+	oilRepo := repository.NewOilInventoryRepository(db)
+	supplierRepo := repository.NewSupplierRepository(db)
+	svc := NewPurchaseOrderService(db, poRepo, oilRepo)
+
+	// 1. Create a supplier and some oils
+	supplier := &entity.Supplier{Name: "Bulk Supplier"}
+	require.NoError(t, supplierRepo.Create(supplier))
+
+	oil1 := &entity.OilInventory{Name: "Oil 1", GramsLeft: entity.Float64Ptr(100)}
+	oil2 := &entity.OilInventory{Name: "Oil 2", GramsLeft: entity.Float64Ptr(200)}
+	require.NoError(t, oilRepo.Create(oil1))
+	require.NoError(t, oilRepo.Create(oil2))
+
+	// 2. Prepare bulk POs
+	pos := []entity.PurchaseOrder{
+		{
+			OilInventoryID: oil1.ID,
+			SupplierID:     supplier.ID,
+			QuantityGrams:  50,
+			UnitPricePerKg: 1000,
+			PurchaseDate:   time.Now().Add(-2 * time.Hour),
+		},
+		{
+			OilInventoryID: oil1.ID,
+			SupplierID:     supplier.ID,
+			QuantityGrams:  30,
+			UnitPricePerKg: 1100, // Latest price for oil1
+			PurchaseDate:   time.Now().Add(-1 * time.Hour),
+		},
+		{
+			OilInventoryID: oil2.ID,
+			SupplierID:     supplier.ID,
+			QuantityGrams:  100,
+			UnitPricePerKg: 2000,
+			PurchaseDate:   time.Now(),
+		},
+	}
+
+	// 3. Execute BulkCreate
+	err = svc.BulkCreate(pos)
+	require.NoError(t, err)
+
+	// 4. Verify POs created
+	listedPOs, err := svc.List()
+	require.NoError(t, err)
+	assert.Len(t, listedPOs, 3)
+
+	// 5. Verify Oil 1 Stock and Metadata
+	updatedOil1, err := oilRepo.GetByID(oil1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 180.0, *updatedOil1.GramsLeft) // 100 + 50 + 30
+	assert.Equal(t, 1100.0, *updatedOil1.PurchasePricePerKg)
+	assert.Equal(t, supplier.ID, *updatedOil1.SupplierID)
+
+	// 6. Verify Oil 2 Stock
+	updatedOil2, err := oilRepo.GetByID(oil2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 300.0, *updatedOil2.GramsLeft) // 200 + 100
+	assert.Equal(t, 2000.0, *updatedOil2.PurchasePricePerKg)
+}
+
+func TestPurchaseOrderService_UpdateAndStockRevert(t *testing.T) {
+	db, err := testutil.SetupTestDB()
+	if err != nil {
+		t.Skip("DB not available")
+	}
+	defer testutil.CleanupTestDB(db)
+
+	poRepo := repository.NewPurchaseOrderRepository(db)
+	oilRepo := repository.NewOilInventoryRepository(db)
+	supplierRepo := repository.NewSupplierRepository(db)
+	svc := NewPurchaseOrderService(db, poRepo, oilRepo)
+
+	supplier := &entity.Supplier{Name: "Supplier"}
+	require.NoError(t, supplierRepo.Create(supplier))
+
+	oil := &entity.OilInventory{Name: "Oil", GramsLeft: entity.Float64Ptr(100)}
+	require.NoError(t, oilRepo.Create(oil))
+
+	po := &entity.PurchaseOrder{
+		OilInventoryID: oil.ID,
+		SupplierID:     supplier.ID,
+		QuantityGrams:  50,
+		UnitPricePerKg: 1000,
+	}
+	require.NoError(t, svc.Create(po))
+
+	// Verify initial stock
+	o, _ := oilRepo.GetByID(oil.ID)
+	assert.Equal(t, 150.0, *o.GramsLeft)
+
+	// Update PO quantity
+	po.QuantityGrams = 100
+	require.NoError(t, svc.Update(po))
+
+	// Verify updated stock (150 - 50 + 100 = 200)
+	o, _ = oilRepo.GetByID(oil.ID)
+	assert.Equal(t, 200.0, *o.GramsLeft)
+
+	// Delete PO
+	require.NoError(t, svc.Delete(po.ID))
+
+	// Verify reverted stock (200 - 100 = 100)
+	o, _ = oilRepo.GetByID(oil.ID)
+	assert.Equal(t, 100.0, *o.GramsLeft)
+}


### PR DESCRIPTION
### 💡 What
Optimized the `PurchaseOrderService.BulkCreate` method to resolve an N+1 database roundtrip bottleneck.

### 🎯 Why
Previously, `BulkCreate` would iterate over purchase orders and call `Create` for each, resulting in multiple queries per item (Create PO, Get Oil, Update Oil). For a large batch, this created significant overhead.

### 📊 Impact
- Reduces database roundtrips from $O(3N)$ to $O(M+1)$, where $N$ is the number of purchase orders and $M$ is the number of unique oils affected.
- Ensures atomic stock updates using `gorm.Expr`.
- Improves data integrity by wrapping the entire batch operation in a single transaction.

### 🔬 Measurement
- Verified backend compilation with `go build ./...`.
- Added `backend/internal/service/purchase_order_service_test.go` to verify correctness of batch aggregation and stock updates.
- Ensured existing repository and service tests pass.

---
*PR created automatically by Jules for task [10352614202791297112](https://jules.google.com/task/10352614202791297112) started by @millennialperfumer-tech*