### PR TITLE
🛡️ Sentinel: Harden WhatsApp Webhook Verification

### DIFF
--- a/backend/internal/automation/whatsapp/handlers.go
+++ b/backend/internal/automation/whatsapp/handlers.go
@@ -3,6 +3,7 @@ package whatsapp
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -177,12 +178,21 @@ func (h *AutomationHandler) SyncTemplateStatus(w http.ResponseWriter, r *http.Re
 func (h *AutomationHandler) WhatsAppWebhook(w http.ResponseWriter, r *http.Request) {
 	// 1. Hub Challenge for verification
 	if r.Method == http.MethodGet {
-		challenge := r.URL.Query().Get("hub.challenge")
-		if challenge != "" {
+		query := r.URL.Query()
+		mode := query.Get("hub.mode")
+		token := query.Get("hub.verify_token")
+		challenge := query.Get("hub.challenge")
+
+		expectedToken := h.settings.GetWhatsAppWebhookVerifyToken()
+
+		// Security: Validate mode and token using constant-time comparison to prevent timing attacks and unauthorized registration.
+		if mode == "subscribe" && subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1 {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(challenge))
 			return
 		}
+		http.Error(w, "Verification failed", http.StatusForbidden)
+		return
 	}
 
 	// 2. Handle status updates


### PR DESCRIPTION
I have hardened the WhatsApp webhook verification process in `backend/internal/automation/whatsapp/handlers.go`. 

Previously, the GET handler for WhatsApp webhooks would return the `hub.challenge` without any validation of the `hub.verify_token`, allowing any entity to potentially register as a webhook recipient or disrupt the existing integration. 

I implemented a check for `hub.mode == "subscribe"` and utilized `subtle.ConstantTimeCompare` to verify the provided `hub.verify_token` against the expected value retrieved from the system settings. This change mitigates both unauthorized registration and potential timing attacks. 

The implementation was verified with a full backend test suite run to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [1459154709944445182](https://jules.google.com/task/1459154709944445182) started by @millennialperfumer-tech*