### PR TITLE
🛡️ Sentinel: [HIGH] Harden AI QueryGuard with Table Allowlist

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `CustomerRepository.List` passed the `sortBy` parameter from user input directly to GORM's `Order()` method without validation.
 **Learning:** ORM methods like GORM's `Order()` often do not parameterize identifiers (like column names) and instead concatenate them into the raw SQL query. This makes them a direct sink for SQL injection if the input is not strictly validated against an allowlist of permitted columns.
 **Prevention:** Always validate dynamic sorting parameters against a hardcoded allowlist map of valid column names before passing them to the database query layer.
+
+## 2026-03-31 - [AI SQL Injection & Information Disclosure via Sensitive Tables]
+**Vulnerability:** AI-triggered raw SQL queries could access sensitive system tables like `users` (containing password hashes) and `app_configs` (containing API keys/secrets) via prompt injection.
+**Learning:** While mutation keywords were blocked, `SELECT` access to the entire public schema was permitted. Relying solely on keyword blocking is insufficient when the database contains sensitive metadata or authentication secrets that can be exfiltrated via simple reads.
+**Prevention:** Implement a strict, "deny-by-default" allowlist of authorized business tables for any AI-triggered or dynamic query engine. Supplement this by filtering sensitive tables out of schema discovery (e.g., `information_schema.tables`) to prevent discovery of their existence.

--- a/backend/internal/repository/ai_read_repository.go
+++ b/backend/internal/repository/ai_read_repository.go
@@ -314,7 +314,13 @@ func (r *gormAIReadRepository) ExecuteRawQuery(sql string) ([]map[string]interfa
 
 func (r *gormAIReadRepository) ListTables() ([]string, error) {
 	var tables []string
-	query := "SELECT table_name FROM information_schema.tables WHERE table_schema='public'"
+	// Security: Filter out sensitive system and authentication tables from schema discovery.
+	query := `
+		SELECT table_name
+		FROM information_schema.tables
+		WHERE table_schema='public'
+		AND table_name NOT IN ('users', 'app_configs', 'app_settings', 'webhook_status')
+	`
 	err := r.db.Raw(query).Scan(&tables).Error
 	return tables, err
 }

--- a/backend/internal/repository/query_guard.go
+++ b/backend/internal/repository/query_guard.go
@@ -10,20 +10,34 @@ import (
 // This is a defense-in-depth layer for AI-generated or AI-triggered queries.
 type QueryGuard struct {
 	blockedPatterns *regexp.Regexp
+	allowedTables   map[string]bool
 }
 
 func NewQueryGuard() *QueryGuard {
 	// Pattern blocks common mutation keywords. Case-insensitive.
 	// We use \b for word boundaries to avoid blocking things like "orders" (contains "order").
-	// Removed REPLACE because it's a common SELECT function.
-	// Removed COMMENT because it triggers on SQL comments.
 	pattern := `(?i)\b(INSERT|UPDATE|DELETE|DROP|ALTER|TRUNCATE|CREATE|GRANT|REVOKE|EXEC|ATTACH|DETACH|MERGE|UPSERT|RENAME)\b`
+
+	allowed := []string{
+		"orders", "order_line_items", "inventory_items", "inventory_mappings", "inventory_logs",
+		"customers", "customer_feedback", "feedback_statuses", "oil_inventory", "suppliers",
+		"purchase_orders", "manufacturing_records", "manufacturing_oils", "manufacturing_products",
+		"planner_tasks", "planner_columns", "planner_boards", "planner_sprints", "planner_task_logs",
+		"social_metrics_history", "social_post_history", "sources", "webhook_events",
+	}
+
+	allowedMap := make(map[string]bool)
+	for _, t := range allowed {
+		allowedMap[t] = true
+	}
+
 	return &QueryGuard{
 		blockedPatterns: regexp.MustCompile(pattern),
+		allowedTables:   allowedMap,
 	}
 }
 
-// IsSafe checks if the SQL string contains any blocked mutation keywords.
+// IsSafe checks if the SQL string contains any blocked mutation keywords or unauthorized tables.
 func (g *QueryGuard) IsSafe(sql string) error {
 	// Normalize whitespace
 	normalized := strings.TrimSpace(strings.Join(strings.Fields(sql), " "))
@@ -33,13 +47,28 @@ func (g *QueryGuard) IsSafe(sql string) error {
 		return fmt.Errorf("SECURITY ALERT: only SELECT queries are allowed")
 	}
 
+	// Block mutation keywords
 	if g.blockedPatterns.MatchString(normalized) {
-		// Log the first 100 characters of the blocked query for debugging
 		snippet := normalized
 		if len(snippet) > 100 {
 			snippet = snippet[:100] + "..."
 		}
 		return fmt.Errorf("SECURITY ALERT: mutation keyword detected in AI query: %s", snippet)
+	}
+
+	// Table Access Control: Verify all tables mentioned are in the allowlist.
+	// We look for patterns like "FROM table_name" or "JOIN table_name".
+	// This regex captures table names after FROM or JOIN, ignoring subqueries or aliases for simplicity.
+	tableRegex := regexp.MustCompile(`(?i)\b(?:FROM|JOIN)\s+([a-z0-9_]+)`)
+	matches := tableRegex.FindAllStringSubmatch(normalized, -1)
+
+	for _, match := range matches {
+		if len(match) > 1 {
+			tableName := strings.ToLower(match[1])
+			if !g.allowedTables[tableName] {
+				return fmt.Errorf("SECURITY ALERT: unauthorized table access detected: %s", tableName)
+			}
+		}
 	}
 	
 	return nil

--- a/backend/internal/repository/query_guard_test.go
+++ b/backend/internal/repository/query_guard_test.go
@@ -1,0 +1,74 @@
+package repository
+
+import (
+	"testing"
+)
+
+func TestQueryGuard_IsSafe(t *testing.T) {
+	guard := NewQueryGuard()
+
+	tests := []struct {
+		name    string
+		query   string
+		wantErr bool
+	}{
+		{
+			name:    "Valid business query",
+			query:   "SELECT * FROM orders LIMIT 10",
+			wantErr: false,
+		},
+		{
+			name:    "Valid join query",
+			query:   "SELECT o.order_number, c.first_name FROM orders o JOIN customers c ON o.customer_phone = c.phone_number",
+			wantErr: false,
+		},
+		{
+			name:    "Mutation blocked (INSERT)",
+			query:   "INSERT INTO orders (id) VALUES (1)",
+			wantErr: true,
+		},
+		{
+			name:    "Mutation blocked (UPDATE)",
+			query:   "UPDATE orders SET status = 'paid' WHERE id = 1",
+			wantErr: true,
+		},
+		{
+			name:    "Sensitive table blocked (users)",
+			query:   "SELECT * FROM users",
+			wantErr: true,
+		},
+		{
+			name:    "Sensitive table blocked (app_configs)",
+			query:   "SELECT * FROM app_configs",
+			wantErr: true,
+		},
+		{
+			name:    "Sensitive table blocked in JOIN",
+			query:   "SELECT * FROM orders JOIN users ON orders.id = users.id",
+			wantErr: true,
+		},
+		{
+			name:    "Unauthorized system table blocked",
+			query:   "SELECT * FROM pg_users",
+			wantErr: true,
+		},
+		{
+			name:    "Non-SELECT query blocked",
+			query:   "DROP TABLE orders",
+			wantErr: true,
+		},
+		{
+			name:    "Query with multiple allowed tables",
+			query:   "SELECT * FROM inventory_items JOIN inventory_mappings ON inventory_items.mi_sku = inventory_mappings.mi_sku",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := guard.IsSafe(tt.query); (err != nil) != tt.wantErr {
+				t.Errorf("QueryGuard.IsSafe() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: AI-triggered raw SQL queries could access sensitive system tables (users, app_configs, etc.) via prompt injection.
🎯 Impact: Attackers could exfiltrate hashed passwords or API secrets.
🔧 Fix: Implemented a strict table allowlist in QueryGuard and filtered sensitive tables from AI schema discovery.
✅ Verification: New unit tests in `query_guard_test.go` pass and verify both allowed and blocked scenarios.

---
*PR created automatically by Jules for task [11705234495933677269](https://jules.google.com/task/11705234495933677269) started by @millennialperfumer-tech*