### PR TITLE
🎨 Palette: Add autoFocus to Add User modal primary input

### DIFF
--- a/frontend/src/Users.tsx
+++ b/frontend/src/Users.tsx
@@ -255,6 +255,7 @@ export function Users({ fetchWithAuth }: UsersProps) {
                                         value={username}
                                         onChange={e => setUsername(e.target.value)}
                                         required
+                                        autoFocus
                                         placeholder="agent@example.com"
                                         style={{ marginTop: '0.25rem' }}
                                     />


### PR DESCRIPTION
### 💡 What:
Added the `autoFocus` attribute to the "Username / Email" input field within the "Add New User" modal.

### 🎯 Why:
To provide a more intuitive and accessible experience. When a user clicks "Add User", they almost always intend to start typing the username immediately. Automatically focusing the field saves a click and follows modern web accessibility standards.

### 📸 Before/After:
**Before:** Modal opens, user must click the input field before typing.
**After:** Modal opens, input field is immediately active and ready for keyboard input.

### ♿ Accessibility:
Improves keyboard navigation by ensuring the logical first interactive element is focused upon modal appearance.

---
*PR created automatically by Jules for task [15219210612766168873](https://jules.google.com/task/15219210612766168873) started by @millennialperfumer-tech*