### PR TITLE
Secure AI-triggered queries with table allowlist

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `CustomerRepository.List` passed the `sortBy` parameter from user input directly to GORM's `Order()` method without validation.
 **Learning:** ORM methods like GORM's `Order()` often do not parameterize identifiers (like column names) and instead concatenate them into the raw SQL query. This makes them a direct sink for SQL injection if the input is not strictly validated against an allowlist of permitted columns.
 **Prevention:** Always validate dynamic sorting parameters against a hardcoded allowlist map of valid column names before passing them to the database query layer.
+
+## 2026-05-20 - [AI Query Table Access Bypass]
+**Vulnerability:** AI-generated SQL queries were only checked for mutation keywords, allowing read-only access to sensitive tables like 'users' and 'app_configs'.
+**Learning:** Defense-in-depth for dynamic SQL must include scope restriction. Blocking 'INSERT/UPDATE/DELETE' prevents destruction but fails to protect data confidentiality if the schema is exposed and all tables are queryable via 'SELECT'.
+**Prevention:** Implement a strict table allowlist at the validation layer and ensure discovery endpoints (like 'ListTables') and schema endpoints (like 'DescribeTable') also enforce this allowlist to maintain a "default-deny" security posture for AI actors.

--- a/backend/internal/repository/ai_read_repository.go
+++ b/backend/internal/repository/ai_read_repository.go
@@ -1,6 +1,9 @@
 package repository
 
 import (
+	"fmt"
+	"strings"
+
 	"mi-tech/internal/entity"
 
 	"gorm.io/gorm"
@@ -49,7 +52,7 @@ func (r *gormAIReadRepository) GetRevenueSummary(startDate, endDate string) (ent
 	if err := r.guard.IsSafe(query); err != nil {
 		return result, err
 	}
-	
+
 	err := r.db.Raw(query, startDate, endDate).Scan(&result).Error
 	result.StartDate = startDate
 	result.EndDate = endDate
@@ -73,7 +76,7 @@ func (r *gormAIReadRepository) GetRevenueByChannel(startDate, endDate string) ([
 	if err := r.guard.IsSafe(query); err != nil {
 		return nil, err
 	}
-	
+
 	err := r.db.Raw(query, startDate, endDate).Scan(&results).Error
 	return results, err
 }
@@ -95,7 +98,7 @@ func (r *gormAIReadRepository) GetRevenueByState(startDate, endDate string) ([]e
 	if err := r.guard.IsSafe(query); err != nil {
 		return nil, err
 	}
-	
+
 	err := r.db.Raw(query, startDate, endDate).Scan(&results).Error
 	return results, err
 }
@@ -116,7 +119,7 @@ func (r *gormAIReadRepository) GetDailyRevenueTrend(startDate, endDate string) (
 	if err := r.guard.IsSafe(query); err != nil {
 		return nil, err
 	}
-	
+
 	err := r.db.Raw(query, startDate, endDate).Scan(&results).Error
 	return results, err
 }
@@ -141,7 +144,7 @@ func (r *gormAIReadRepository) GetTopProducts(startDate, endDate string, limit i
 	if err := r.guard.IsSafe(query); err != nil {
 		return nil, err
 	}
-	
+
 	err := r.db.Raw(query, startDate, endDate, limit).Scan(&results).Error
 	return results, err
 }
@@ -199,19 +202,19 @@ func (r *gormAIReadRepository) GetProductPerformance(sku string) (entity.AIProdu
 
 func (r *gormAIReadRepository) GetCustomerSegmentation() (entity.AICustomerSegments, error) {
 	var result entity.AICustomerSegments
-	
+
 	var total int64
 	r.db.Model(&entity.Customer{}).Count(&total)
 	result.TotalCustomers = int(total)
-	
+
 	r.db.Raw("SELECT COUNT(*) FROM customers WHERE created_at >= NOW() - INTERVAL '30 days'").Scan(&result.NewCustomers)
-	
+
 	// Repeat Rate
 	var totalCustomersWithOrders int64
 	r.db.Raw("SELECT COUNT(DISTINCT customer_phone) FROM orders").Scan(&totalCustomersWithOrders)
 	var repeatCustomers int64
 	r.db.Raw("SELECT COUNT(*) FROM (SELECT customer_phone FROM orders GROUP BY customer_phone HAVING COUNT(*) > 1) as t").Scan(&repeatCustomers)
-	
+
 	if totalCustomersWithOrders > 0 {
 		result.RepeatRate = float64(repeatCustomers) / float64(totalCustomersWithOrders)
 	}
@@ -276,7 +279,7 @@ func (r *gormAIReadRepository) GetInventorySnapshot() ([]entity.AIInventoryStatu
 
 func (r *gormAIReadRepository) GetBusinessSnapshot() (entity.AIBusinessSnapshot, error) {
 	var snap entity.AIBusinessSnapshot
-	
+
 	// MTD
 	r.db.Raw(`
 		SELECT COALESCE(SUM(total_price), 0), COUNT(*) 
@@ -313,13 +316,31 @@ func (r *gormAIReadRepository) ExecuteRawQuery(sql string) ([]map[string]interfa
 }
 
 func (r *gormAIReadRepository) ListTables() ([]string, error) {
-	var tables []string
+	var allTables []string
 	query := "SELECT table_name FROM information_schema.tables WHERE table_schema='public'"
-	err := r.db.Raw(query).Scan(&tables).Error
-	return tables, err
+	err := r.db.Raw(query).Scan(&allTables).Error
+	if err != nil {
+		return nil, err
+	}
+
+	// Security: Filter out tables that are not in the QueryGuard allowlist.
+	// This prevents the AI from even discovering sensitive tables like 'users' or 'app_configs'.
+	var allowedTables []string
+	for _, t := range allTables {
+		if r.guard.allowedTables[strings.ToLower(t)] {
+			allowedTables = append(allowedTables, t)
+		}
+	}
+
+	return allowedTables, nil
 }
 
 func (r *gormAIReadRepository) DescribeTable(tableName string) ([]map[string]interface{}, error) {
+	// Security: Validate table name against the allowlist before describing it.
+	if !r.guard.allowedTables[strings.ToLower(tableName)] {
+		return nil, fmt.Errorf("SECURITY ALERT: describing table '%s' is not allowed", tableName)
+	}
+
 	var columns []map[string]interface{}
 	query := "SELECT column_name, data_type, is_nullable FROM information_schema.columns WHERE table_name = ?"
 	err := r.db.Raw(query, tableName).Scan(&columns).Error

--- a/backend/internal/repository/query_guard.go
+++ b/backend/internal/repository/query_guard.go
@@ -10,39 +10,122 @@ import (
 // This is a defense-in-depth layer for AI-generated or AI-triggered queries.
 type QueryGuard struct {
 	blockedPatterns *regexp.Regexp
+	allowedTables   map[string]bool
 }
 
 func NewQueryGuard() *QueryGuard {
 	// Pattern blocks common mutation keywords. Case-insensitive.
 	// We use \b for word boundaries to avoid blocking things like "orders" (contains "order").
-	// Removed REPLACE because it's a common SELECT function.
-	// Removed COMMENT because it triggers on SQL comments.
 	pattern := `(?i)\b(INSERT|UPDATE|DELETE|DROP|ALTER|TRUNCATE|CREATE|GRANT|REVOKE|EXEC|ATTACH|DETACH|MERGE|UPSERT|RENAME)\b`
+
+	// allowedTables defines a strict allowlist of tables that AI is permitted to query.
+	// Sensitive tables like 'users', 'app_configs', 'webhooks' etc. are strictly excluded.
+	allowedTables := map[string]bool{
+		"orders":                 true,
+		"order_line_items":       true,
+		"customers":              true,
+		"inventory_items":        true,
+		"inventory_logs":         true,
+		"inventory_mappings":     true,
+		"suppliers":              true,
+		"oil_inventory":          true,
+		"manufacturing_records":  true,
+		"manufacturing_oils":     true,
+		"manufacturing_products": true,
+		"automation_templates":   true,
+		"social_metrics":         true,
+		"customer_feedback":      true,
+		"planner_boards":         true,
+		"planner_columns":        true,
+		"planner_tasks":          true,
+	}
+
 	return &QueryGuard{
 		blockedPatterns: regexp.MustCompile(pattern),
+		allowedTables:   allowedTables,
 	}
 }
 
-// IsSafe checks if the SQL string contains any blocked mutation keywords.
+// IsSafe checks if the SQL string contains any blocked mutation keywords
+// and ensures only allowed tables are referenced.
 func (g *QueryGuard) IsSafe(sql string) error {
 	// Normalize whitespace
 	normalized := strings.TrimSpace(strings.Join(strings.Fields(sql), " "))
-	
+	upperSQL := strings.ToUpper(normalized)
+
 	// Must start with SELECT
-	if !strings.HasPrefix(strings.ToUpper(normalized), "SELECT") {
+	if !strings.HasPrefix(upperSQL, "SELECT") {
 		return fmt.Errorf("SECURITY ALERT: only SELECT queries are allowed")
 	}
 
 	if g.blockedPatterns.MatchString(normalized) {
-		// Log the first 100 characters of the blocked query for debugging
 		snippet := normalized
 		if len(snippet) > 100 {
 			snippet = snippet[:100] + "..."
 		}
 		return fmt.Errorf("SECURITY ALERT: mutation keyword detected in AI query: %s", snippet)
 	}
-	
+
+	// Enhanced table allowlist validation.
+	// This covers 'FROM table', 'JOIN table', and comma-separated 'FROM table1, table2'.
+	// It also handles quoted identifiers and schema prefixes like 'public.table'.
+
+	tokens := strings.Fields(normalized)
+	for i, token := range tokens {
+		upperToken := strings.ToUpper(token)
+		if upperToken == "FROM" || upperToken == "JOIN" {
+			if i+1 < len(tokens) {
+				for j := i + 1; j < len(tokens); j++ {
+					subToken := tokens[j]
+					upperSub := strings.ToUpper(subToken)
+					if isKeyword(upperSub) {
+						break
+					}
+
+					refs := strings.Split(subToken, ",")
+					for _, ref := range refs {
+						ref = strings.TrimSpace(ref)
+						if ref == "" {
+							continue
+						}
+
+						// The first part is the table name
+						tableName := strings.Split(ref, " ")[0]
+						// Strip ALL quotes first
+						tableName = strings.ReplaceAll(tableName, `"`, "")
+						tableName = strings.ReplaceAll(tableName, `'`, "")
+						tableName = strings.ReplaceAll(tableName, "`", "")
+
+						if dotIndex := strings.LastIndex(tableName, "."); dotIndex != -1 {
+							tableName = tableName[dotIndex+1:]
+						}
+						tableName = strings.ToLower(tableName)
+
+						if tableName != "" && !g.allowedTables[tableName] {
+							return fmt.Errorf("SECURITY ALERT: access to table '%s' is not allowed", tableName)
+						}
+					}
+
+					if !strings.Contains(subToken, ",") && j > i+1 {
+						// Likely alias or ON clause
+					}
+				}
+			}
+		}
+	}
+
 	return nil
+}
+
+func isKeyword(s string) bool {
+	keywords := map[string]bool{
+		"WHERE": true, "GROUP": true, "ORDER": true, "LIMIT": true,
+		"OFFSET": true, "FETCH": true, "UNION": true, "INTERSECT": true,
+		"EXCEPT": true, "ON": true, "USING": true, "LEFT": true,
+		"RIGHT": true, "INNER": true, "OUTER": true, "CROSS": true,
+		"FULL": true, "JOIN": true,
+	}
+	return keywords[s]
 }
 
 // WrapQuery is a helper to validate a query before returning it.

--- a/backend/internal/repository/query_guard_test.go
+++ b/backend/internal/repository/query_guard_test.go
@@ -1,0 +1,100 @@
+package repository
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestQueryGuard_IsSafe(t *testing.T) {
+	guard := NewQueryGuard()
+
+	tests := []struct {
+		name     string
+		query    string
+		isSafe   bool
+		errMatch string
+	}{
+		{
+			name:   "Valid SELECT",
+			query:  "SELECT * FROM orders",
+			isSafe: true,
+		},
+		{
+			name:   "Valid JOIN",
+			query:  "SELECT * FROM orders JOIN order_line_items ON orders.id = order_line_items.order_id",
+			isSafe: true,
+		},
+		{
+			name:   "Valid Multi-FROM",
+			query:  "SELECT * FROM orders, order_line_items WHERE orders.id = order_line_items.order_id",
+			isSafe: true,
+		},
+		{
+			name:   "Valid Schema Prefix",
+			query:  "SELECT * FROM public.orders",
+			isSafe: true,
+		},
+		{
+			name:   "Valid Quoted",
+			query:  `SELECT * FROM "orders"`,
+			isSafe: true,
+		},
+		{
+			name:     "Mutation keyword: INSERT",
+			query:    "INSERT INTO orders (id) VALUES (1)",
+			isSafe:   false,
+			errMatch: "only SELECT queries are allowed",
+		},
+		{
+			name:     "Mutation keyword: embedded",
+			query:    "SELECT * FROM orders; DROP TABLE users",
+			isSafe:   false,
+			errMatch: "mutation keyword detected",
+		},
+		{
+			name:     "Sensitive table: users",
+			query:    "SELECT * FROM users",
+			isSafe:   false,
+			errMatch: "access to table 'users' is not allowed",
+		},
+		{
+			name:     "Sensitive table: app_configs",
+			query:    "SELECT * FROM app_configs",
+			isSafe:   false,
+			errMatch: "access to table 'app_configs' is not allowed",
+		},
+		{
+			name:     "Sensitive table in JOIN",
+			query:    "SELECT * FROM orders JOIN users ON orders.customer_id = users.id",
+			isSafe:   false,
+			errMatch: "access to table 'users' is not allowed",
+		},
+		{
+			name:     "Sensitive table in Multi-FROM",
+			query:    "SELECT * FROM orders, users",
+			isSafe:   false,
+			errMatch: "access to table 'users' is not allowed",
+		},
+		{
+			name:     "Sensitive table with Quoted and Prefix",
+			query:    `SELECT * FROM public."users"`,
+			isSafe:   false,
+			errMatch: "access to table 'users' is not allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := guard.IsSafe(tt.query)
+			if tt.isSafe {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "SECURITY ALERT")
+				if tt.errMatch != "" {
+					assert.Contains(t, err.Error(), tt.errMatch)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Enhanced the security of AI-driven database interactions by implementing a strict table allowlist. This prevents the AI from discovering or querying sensitive system tables like 'users' or 'app_configs', even with read-only SELECT queries. The QueryGuard was improved to handle complex SQL syntax more robustly.

---
*PR created automatically by Jules for task [8571359296923617324](https://jules.google.com/task/8571359296923617324) started by @millennialperfumer-tech*