### PR TITLE
🎨 Palette: Replace native alerts with themed toasts

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -11,8 +11,8 @@ export default defineConfig([
     files: ['**/*.{ts,tsx}'],
     extends: [
       js.configs.recommended,
-      tseslint.configs.recommended,
-      reactHooks.configs.flat.recommended,
+      ...tseslint.configs.recommended,
+      reactHooks.configs['recommended-latest'],
       reactRefresh.configs.vite,
     ],
     languageOptions: {

--- a/frontend/src/TemplateMapper.tsx
+++ b/frontend/src/TemplateMapper.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { API_BASE } from './api';
 import type { Template } from './AutomationTemplates';
+import { useToast } from './ToastContext';
 
 interface TemplateMapperProps {
   template: Template;
@@ -32,6 +33,7 @@ const availableVariables = [
 ];
 
 export function TemplateMapper({ template, onBack, fetchWithAuth }: TemplateMapperProps) {
+  const { success: toastSuccess, error: toastError } = useToast();
   const [mappings, setMappings] = useState<Record<string, string>>(template.variable_mappings || {});
   const [isSaving, setIsSaving] = useState(false);
   
@@ -81,15 +83,15 @@ export function TemplateMapper({ template, onBack, fetchWithAuth }: TemplateMapp
       });
 
       if (resp.ok) {
-        alert('Variable mappings saved successfully!');
+        toastSuccess('Variable mappings saved successfully!');
         onBack();
       } else {
         const err = await resp.text();
-        alert(`Failed to save mappings: ${err}`);
+        toastError(`Failed to save mappings: ${err}`);
       }
     } catch (err) {
       console.error(err);
-      alert('Network error while saving mappings.');
+      toastError('Network error while saving mappings.');
     } finally {
       setIsSaving(false);
     }

--- a/frontend/src/WhatsAppChat.tsx
+++ b/frontend/src/WhatsAppChat.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { API_BASE } from './api';
+import { useToast } from './ToastContext';
 import './WhatsAppChat.css';
 
 interface Conversation {
@@ -100,6 +101,7 @@ function WhatsAppMediaItem({ filename, fetchWithAuth, onImageLoad, type }: {
 }
 
 export function WhatsAppChat({ fetchWithAuth }: WhatsAppChatProps) {
+  const { error: toastError, warning: toastWarning } = useToast();
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [selectedConversation, setSelectedConversation] = useState<Conversation | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -245,7 +247,7 @@ export function WhatsAppChat({ fetchWithAuth }: WhatsAppChatProps) {
     // Strict 16MB limit as requested by user
     const MAX_SIZE = 16 * 1024 * 1024;
     if (file.size > MAX_SIZE) {
-      alert(`File too large (${(file.size / 1024 / 1024).toFixed(1)}MB). Maximum allowed is 16MB.`);
+      toastWarning(`File too large (${(file.size / 1024 / 1024).toFixed(1)}MB). Maximum allowed is 16MB.`);
       if (fileInputRef.current) fileInputRef.current.value = '';
       return;
     }
@@ -289,7 +291,7 @@ export function WhatsAppChat({ fetchWithAuth }: WhatsAppChatProps) {
       }
     } catch (err) {
       console.error('Media upload error:', err);
-      alert('Failed to send media file');
+      toastError('Failed to send media file');
     } finally {
       setIsUploadingMedia(false);
       if (fileInputRef.current) fileInputRef.current.value = '';


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Replaced native browser `alert()` calls with themed toast notifications in the following areas:
- `TemplateMapper.tsx`: Successful mapping save and error handling.
- `WhatsAppChat.tsx`: File size limit warnings and media upload errors.

### 🎯 Why: The user problem it solves
Browser alerts are intrusive, blocking, and inconsistent with the application's modern design. Toasts provide non-blocking, integrated feedback that allows the user to continue their workflow without interruption.

### 📸 Before/After:
- **Before**: Standard browser popup dialog.
- **After**: Themed green (success), red (error), or yellow (warning) toast notifications in the top-right corner.

### ♿ Accessibility: Any a11y improvements made
Toasts are implemented using the existing `ToastProvider`, which follows standard notification patterns.

### 🛠️ Technical Fixes
Updated `frontend/eslint.config.js` to resolve a `TypeError` when running linting, ensuring better developer experience and code quality tracking.

---
*PR created automatically by Jules for task [13586826627964919144](https://jules.google.com/task/13586826627964919144) started by @millennialperfumer-tech*