### PR TITLE
🎨 Palette: Standardize creation modals with autofocus and loading states

### DIFF
--- a/frontend/src/Customers.tsx
+++ b/frontend/src/Customers.tsx
@@ -1274,6 +1274,7 @@ export function Customers({ fetchWithAuth, showClearButton = false, bulkSuffix =
                                             <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-secondary)', marginBottom: '6px' }}>First Name</label>
                                             <input
                                                 type="text"
+                                                autoFocus
                                                 className="form-input"
                                                 value={customerForm.first_name || ''}
                                                 onChange={e => setCustomerForm({...customerForm, first_name: e.target.value})}

--- a/frontend/src/Products.tsx
+++ b/frontend/src/Products.tsx
@@ -83,6 +83,7 @@ export const Products: React.FC<{ token: string | null, userRole?: string, appCo
   const [syncEndDate, setSyncEndDate] = useState(new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Kolkata' }));
   const [stagedProducts, setStagedProducts] = useState<InventoryItem[]>([]);
   const [selectedStagedIds, setSelectedStagedIds] = useState<Set<string>>(new Set());
+  const [isSaving, setIsSaving] = useState(false);
 
   // New Product Form
   const [formData, setFormData] = useState({
@@ -318,6 +319,8 @@ export const Products: React.FC<{ token: string | null, userRole?: string, appCo
 
   const handleCreateItem = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isSaving) return;
+    setIsSaving(true);
     try {
       const resp = await fetchWithAuth(`${API_BASE}/api/inventory`, {
         method: 'POST',
@@ -333,6 +336,8 @@ export const Products: React.FC<{ token: string | null, userRole?: string, appCo
       }
     } catch (err) {
       toastError('Error creating product');
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -754,6 +759,7 @@ export const Products: React.FC<{ token: string | null, userRole?: string, appCo
                   <input 
                     type="text" 
                     required
+                    autoFocus
                     value={formData.title} 
                     onChange={e => setFormData({...formData, title: e.target.value})}
                   />
@@ -777,8 +783,10 @@ export const Products: React.FC<{ token: string | null, userRole?: string, appCo
                 </div>
               </div>
               <div className="modal-actions" style={{ marginTop: '2rem' }}>
-                <button type="button" className="btn-secondary" onClick={() => setShowAddModal(false)}>Cancel</button>
-                <button type="submit" className="btn-primary">Create Product</button>
+                <button type="button" className="btn-secondary" onClick={() => setShowAddModal(false)} disabled={isSaving}>Cancel</button>
+                <button type="submit" className="btn-primary" disabled={isSaving}>
+                  {isSaving ? 'Creating...' : 'Create Product'}
+                </button>
               </div>
             </form>
           </div>

--- a/frontend/src/Users.tsx
+++ b/frontend/src/Users.tsx
@@ -252,6 +252,7 @@ export function Users({ fetchWithAuth }: UsersProps) {
                                     <label style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--text-primary)' }}>Username / Email</label>
                                     <input 
                                         type="email" 
+                                        autoFocus
                                         value={username}
                                         onChange={e => setUsername(e.target.value)}
                                         required


### PR DESCRIPTION
I implemented a series of micro-UX improvements across the core creation modals (Products, Customers, and Users) to enhance accessibility and user interaction flow.

### Key Changes:
- **Autofocus Optimization:** Added the `autoFocus` attribute to the primary input field in the "Add Product" (Product Title), "Add Customer" (First Name), and "Add User" (Username / Email) modals. This allows users to start typing immediately without manually clicking the field.
- **Async Feedback & Safety:** In `Products.tsx`, I introduced an `isSaving` state. When creating a new product, the submit button now displays "Creating...", becomes disabled, and the "Cancel" button is also disabled. This provides clear feedback and prevents accidental duplicate submissions.
- **Robust State Management:** The loading state is managed within a `try...finally` block to ensure the UI remains interactive even if a request fails.

These small touches make the interface feel more responsive, professional, and accessible for keyboard-heavy workflows.

---
*PR created automatically by Jules for task [1476908524223886998](https://jules.google.com/task/1476908524223886998) started by @millennialperfumer-tech*