### PR TITLE
🛡️ Sentinel: [HIGH] Fix OTP timing attack vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `CustomerRepository.List` passed the `sortBy` parameter from user input directly to GORM's `Order()` method without validation.
 **Learning:** ORM methods like GORM's `Order()` often do not parameterize identifiers (like column names) and instead concatenate them into the raw SQL query. This makes them a direct sink for SQL injection if the input is not strictly validated against an allowlist of permitted columns.
 **Prevention:** Always validate dynamic sorting parameters against a hardcoded allowlist map of valid column names before passing them to the database query layer.
+
+## 2026-05-20 - [OTP Timing Attack Regression]
+**Vulnerability:** 2FA OTP verification used standard string comparison (`!=`), susceptible to timing side-channel attacks.
+**Learning:** Re-implementation of authentication logic can lead to security regressions if standard language equality operators are used instead of constant-time comparison functions for secrets.
+**Prevention:** Use `crypto/subtle.ConstantTimeCompare` for all sensitive secret comparisons, especially in authentication and OTP verification paths, to ensure response time does not leak information about the secret's content.

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"crypto/rand"
+	"crypto/subtle"
 	"io"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -126,7 +127,7 @@ func (s *AuthService) VerifyOTP(username, otp string) (string, error) {
 		return "", errors.New("verification code expired or not found")
 	}
 
-	if user.OTPCode != otp {
+	if subtle.ConstantTimeCompare([]byte(user.OTPCode), []byte(otp)) != 1 {
 		return "", errors.New("invalid verification code")
 	}
 


### PR DESCRIPTION
This PR fixes a security regression in the 2FA verification logic. The previous implementation used standard string comparison (`!=`) for checking OTP codes, which is vulnerable to timing side-channel attacks. By switching to `crypto/subtle.ConstantTimeCompare`, we ensure that the verification process is resistant to such attacks.

Verification:
- Ran `go test ./...` in the `backend` directory. All tests passed.
- Code review confirmed the fix is correct and follows security best practices.

---
*PR created automatically by Jules for task [5678091315508951571](https://jules.google.com/task/5678091315508951571) started by @millennialperfumer-tech*