### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix CORS wildcard credentials vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `CustomerRepository.List` passed the `sortBy` parameter from user input directly to GORM's `Order()` method without validation.
 **Learning:** ORM methods like GORM's `Order()` often do not parameterize identifiers (like column names) and instead concatenate them into the raw SQL query. This makes them a direct sink for SQL injection if the input is not strictly validated against an allowlist of permitted columns.
 **Prevention:** Always validate dynamic sorting parameters against a hardcoded allowlist map of valid column names before passing them to the database query layer.
+
+## 2026-05-31 - [CORS Wildcard and Credentials Conflict]
+**Vulnerability:** `CORSMiddleware` incorrectly set `Access-Control-Allow-Credentials: true` when a wildcard `*` was present in `ALLOWED_ORIGINS`.
+**Learning:** Browsers block requests where `Access-Control-Allow-Origin` is `*` and `Access-Control-Allow-Credentials` is `true`. The code attempted to bypass this by echoing the `Origin` header even when the "allowance" came from a wildcard, which reintroduced a vulnerability where any site could make authenticated requests.
+**Prevention:** If a wildcard `*` is used, the response must set `Access-Control-Allow-Origin: *` and omit `Access-Control-Allow-Credentials`. Credentials must only be allowed for explicitly listed origins.

--- a/backend/internal/server/cors_security_test.go
+++ b/backend/internal/server/cors_security_test.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCORSMiddleware_WildcardSecurity(t *testing.T) {
+	// Setup allowed origins with wildcard
+	t.Setenv("ALLOWED_ORIGINS", "*")
+
+	handler := CORSMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/api/health", nil)
+	req.Header.Set("Origin", "http://evil.com")
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	originHeader := res.Header().Get("Access-Control-Allow-Origin")
+	credsHeader := res.Header().Get("Access-Control-Allow-Credentials")
+
+	if originHeader == "http://evil.com" && credsHeader == "true" {
+		t.Errorf("SECURITY VULNERABILITY: Wildcard ALLOWED_ORIGINS allows arbitrary origin %q with credentials", originHeader)
+	}
+}

--- a/backend/internal/server/middleware.go
+++ b/backend/internal/server/middleware.go
@@ -27,30 +27,39 @@ func CORSMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		allowedOriginsEnv := os.Getenv("ALLOWED_ORIGINS")
 		rawOrigin := r.Header.Get("Origin")
 		origin := normalizeOrigin(rawOrigin)
-		isAllowed := false
+		isExplicitlyAllowed := false
+		isWildcardAllowed := false
 
 		// Always set Vary: Origin to handle caching behind proxies/CDNs
 		w.Header().Add("Vary", "Origin")
 
 		if rawOrigin == "" {
 			// If no origin, we can consider it a direct request or same-origin
-			isAllowed = true
+			isExplicitlyAllowed = true
 		} else if allowedOriginsEnv != "" {
 			allowedOrigins := strings.Split(allowedOriginsEnv, ",")
 			for _, allowed := range allowedOrigins {
 				trimmed := normalizeOrigin(allowed)
-				if trimmed == "*" || origin == trimmed {
-					isAllowed = true
+				if origin == trimmed {
+					isExplicitlyAllowed = true
 					break
+				}
+				if trimmed == "*" {
+					isWildcardAllowed = true
 				}
 			}
 		}
 
-		if isAllowed {
+		if isExplicitlyAllowed || isWildcardAllowed {
 			if rawOrigin != "" {
-				// Use the actual origin for the allow header to support multiple origins with credentials
-				w.Header().Set("Access-Control-Allow-Origin", rawOrigin)
-				w.Header().Set("Access-Control-Allow-Credentials", "true")
+				if isExplicitlyAllowed {
+					// Use the actual origin for the allow header to support multiple origins with credentials
+					w.Header().Set("Access-Control-Allow-Origin", rawOrigin)
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
+				} else {
+					// Wildcard allowed - must NOT use credentials if origin is "*"
+					w.Header().Set("Access-Control-Allow-Origin", "*")
+				}
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH")
 				w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, X-Requested-With, X-Amz-Date, X-Api-Key, X-Amz-Security-Token, X-Forwarded-For, X-Real-IP, Origin, Access-Control-Request-Method, Access-Control-Request-Headers")
 				w.Header().Set("Access-Control-Max-Age", "86400") // 24 hours
@@ -61,7 +70,7 @@ func CORSMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		}
 
 		if r.Method == http.MethodOptions {
-			if isAllowed {
+			if isExplicitlyAllowed || isWildcardAllowed {
 				w.WriteHeader(http.StatusOK)
 			} else {
 				w.WriteHeader(http.StatusForbidden)


### PR DESCRIPTION
I identified and fixed a critical security vulnerability in the CORS middleware.

🚨 **Severity:** CRITICAL/HIGH
💡 **Vulnerability:** The middleware was echoing back the request's `Origin` and setting `Access-Control-Allow-Credentials: true` even when the configuration only allowed a wildcard `*`.
🎯 **Impact:** This allowed any website to make authenticated requests to the API on behalf of a logged-in user, effectively bypassing CORS protections.
🔧 **Fix:** Refactored `CORSMiddleware` to differentiate between explicit origin matches and wildcard matches. It now only sets `Access-Control-Allow-Credentials: true` and echoes the origin for explicit matches. For wildcard matches, it sets `Access-Control-Allow-Origin: *` and omits the credentials header.
✅ **Verification:** Added `backend/internal/server/cors_security_test.go` which specifically tests the wildcard scenario and confirms that credentials are not allowed. All backend tests pass.

---
*PR created automatically by Jules for task [4949529689871661289](https://jules.google.com/task/4949529689871661289) started by @millennialperfumer-tech*