### PR TITLE
🛡️ Sentinel: [security improvement] Enforce table allowlist in AI QueryGuard

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `CustomerRepository.List` passed the `sortBy` parameter from user input directly to GORM's `Order()` method without validation.
 **Learning:** ORM methods like GORM's `Order()` often do not parameterize identifiers (like column names) and instead concatenate them into the raw SQL query. This makes them a direct sink for SQL injection if the input is not strictly validated against an allowlist of permitted columns.
 **Prevention:** Always validate dynamic sorting parameters against a hardcoded allowlist map of valid column names before passing them to the database query layer.
+
+## 2026-06-01 - [AI Query Table Allowlist]
+**Vulnerability:** AI-generated raw queries and schema listing exposed sensitive tables like 'users' and 'app_configs'.
+**Learning:** Simple mutation keyword blocking is insufficient for AI tools with raw SQL access. Table-level access control is required to prevent credential and secret exfiltration. Parsing SQL with regex is prone to bypasses (e.g., comma-separated tables, aliases), necessitating a more robust extraction logic.
+**Prevention:** Enforce a strict table allowlist in the AI query guard and use a robust extraction pattern for 'FROM' and 'JOIN' clauses that accounts for multi-table queries and aliases.

--- a/backend/internal/repository/ai_read_repository.go
+++ b/backend/internal/repository/ai_read_repository.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"fmt"
 	"mi-tech/internal/entity"
 
 	"gorm.io/gorm"
@@ -313,13 +314,27 @@ func (r *gormAIReadRepository) ExecuteRawQuery(sql string) ([]map[string]interfa
 }
 
 func (r *gormAIReadRepository) ListTables() ([]string, error) {
-	var tables []string
+	var allTables []string
 	query := "SELECT table_name FROM information_schema.tables WHERE table_schema='public'"
-	err := r.db.Raw(query).Scan(&tables).Error
-	return tables, err
+	err := r.db.Raw(query).Scan(&allTables).Error
+	if err != nil {
+		return nil, err
+	}
+
+	var allowedTables []string
+	for _, t := range allTables {
+		if r.guard.IsTableAllowed(t) {
+			allowedTables = append(allowedTables, t)
+		}
+	}
+	return allowedTables, nil
 }
 
 func (r *gormAIReadRepository) DescribeTable(tableName string) ([]map[string]interface{}, error) {
+	if !r.guard.IsTableAllowed(tableName) {
+		return nil, fmt.Errorf("SECURITY ALERT: access to table metadata for '%s' is restricted", tableName)
+	}
+
 	var columns []map[string]interface{}
 	query := "SELECT column_name, data_type, is_nullable FROM information_schema.columns WHERE table_name = ?"
 	err := r.db.Raw(query, tableName).Scan(&columns).Error

--- a/backend/internal/repository/query_guard.go
+++ b/backend/internal/repository/query_guard.go
@@ -6,24 +6,51 @@ import (
 	"strings"
 )
 
-// QueryGuard provides runtime safety by blocking SQL mutation keywords.
+// QueryGuard provides runtime safety by blocking SQL mutation keywords and enforcing a table allowlist.
 // This is a defense-in-depth layer for AI-generated or AI-triggered queries.
 type QueryGuard struct {
 	blockedPatterns *regexp.Regexp
+	fromClauseRegex *regexp.Regexp
+	joinClauseRegex *regexp.Regexp
+	allowedTables   map[string]bool
 }
 
 func NewQueryGuard() *QueryGuard {
 	// Pattern blocks common mutation keywords. Case-insensitive.
-	// We use \b for word boundaries to avoid blocking things like "orders" (contains "order").
-	// Removed REPLACE because it's a common SELECT function.
-	// Removed COMMENT because it triggers on SQL comments.
 	pattern := `(?i)\b(INSERT|UPDATE|DELETE|DROP|ALTER|TRUNCATE|CREATE|GRANT|REVOKE|EXEC|ATTACH|DETACH|MERGE|UPSERT|RENAME)\b`
+
+	// Extracts the content after FROM until the next major keyword (WHERE, GROUP, ORDER, etc.)
+	// Handles comma-separated tables.
+	fromPattern := `(?i)\bFROM\s+([^;]+?)(?:\s+(?:WHERE|GROUP|ORDER|LIMIT|JOIN|HAVING|UNION|INTERSECT|EXCEPT)|$)`
+
+	// Extracts table names after JOIN.
+	joinPattern := `(?i)\bJOIN\s+([a-zA-Z0-9_.]+)`
+
+	// Strict allowlist of tables the AI is permitted to query.
+	allowed := map[string]bool{
+		"orders":                 true,
+		"order_line_items":       true,
+		"customers":              true,
+		"inventory_items":        true,
+		"sources":                true,
+		"webhook_events":         true,
+		"oil_inventory":          true,
+		"manufacturing_records":  true,
+		"manufacturing_products": true,
+		"purchase_orders":        true,
+		"feedback":               true,
+		"planner_tasks":          true,
+	}
+
 	return &QueryGuard{
 		blockedPatterns: regexp.MustCompile(pattern),
+		fromClauseRegex: regexp.MustCompile(fromPattern),
+		joinClauseRegex: regexp.MustCompile(joinPattern),
+		allowedTables:   allowed,
 	}
 }
 
-// IsSafe checks if the SQL string contains any blocked mutation keywords.
+// IsSafe checks if the SQL string contains any blocked mutation keywords and only accesses allowed tables.
 func (g *QueryGuard) IsSafe(sql string) error {
 	// Normalize whitespace
 	normalized := strings.TrimSpace(strings.Join(strings.Fields(sql), " "))
@@ -33,16 +60,81 @@ func (g *QueryGuard) IsSafe(sql string) error {
 		return fmt.Errorf("SECURITY ALERT: only SELECT queries are allowed")
 	}
 
+	// 1. Check for mutation keywords
 	if g.blockedPatterns.MatchString(normalized) {
-		// Log the first 100 characters of the blocked query for debugging
 		snippet := normalized
 		if len(snippet) > 100 {
 			snippet = snippet[:100] + "..."
 		}
 		return fmt.Errorf("SECURITY ALERT: mutation keyword detected in AI query: %s", snippet)
 	}
+
+	// 2. Check for unauthorized table access in FROM clauses
+	fromMatches := g.fromClauseRegex.FindAllStringSubmatch(normalized, -1)
+	for _, match := range fromMatches {
+		if len(match) > 1 {
+			// Content of the FROM clause, e.g. "orders, users" or "orders o"
+			content := match[1]
+			// Split by comma for multiple tables
+			tables := strings.Split(content, ",")
+			for _, t := range tables {
+				if err := g.validateTableString(t); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// 3. Check for unauthorized table access in JOIN clauses
+	joinMatches := g.joinClauseRegex.FindAllStringSubmatch(normalized, -1)
+	for _, match := range joinMatches {
+		if len(match) > 1 {
+			if err := g.validateTableString(match[1]); err != nil {
+				return err
+			}
+		}
+	}
 	
 	return nil
+}
+
+// validateTableString cleans up a table string (removes aliases and whitespace) and checks the allowlist.
+func (g *QueryGuard) validateTableString(t string) error {
+	t = strings.TrimSpace(t)
+	if t == "" {
+		return nil
+	}
+
+	// Detect subqueries (contains parentheses)
+	if strings.Contains(t, "(") {
+		return fmt.Errorf("SECURITY ALERT: subqueries in FROM/JOIN are restricted for AI analysis")
+	}
+
+	// Remove aliases (take the first word)
+	parts := strings.Fields(t)
+	if len(parts) == 0 {
+		return nil
+	}
+	tableName := strings.ToLower(parts[0])
+
+	// Handle schema prefix if present (e.g., public.orders)
+	if parts := strings.Split(tableName, "."); len(parts) > 1 {
+		tableName = parts[len(parts)-1]
+	}
+
+	if !g.allowedTables[tableName] {
+		return fmt.Errorf("SECURITY ALERT: access to table '%s' is restricted", tableName)
+	}
+	return nil
+}
+
+// IsTableAllowed checks if a specific table name is in the allowlist.
+func (g *QueryGuard) IsTableAllowed(tableName string) bool {
+	tableName = strings.ToLower(tableName)
+	if parts := strings.Split(tableName, "."); len(parts) > 1 {
+		tableName = parts[len(parts)-1]
+	}
+	return g.allowedTables[tableName]
 }
 
 // WrapQuery is a helper to validate a query before returning it.

--- a/backend/internal/repository/query_guard_test.go
+++ b/backend/internal/repository/query_guard_test.go
@@ -1,0 +1,133 @@
+package repository
+
+import (
+	"testing"
+)
+
+func TestQueryGuard_IsSafe(t *testing.T) {
+	guard := NewQueryGuard()
+
+	tests := []struct {
+		name    string
+		sql     string
+		wantErr bool
+	}{
+		{
+			name:    "Valid simple select",
+			sql:     "SELECT * FROM orders",
+			wantErr: false,
+		},
+		{
+			name:    "Valid select with join",
+			sql:     "SELECT * FROM orders JOIN order_line_items ON orders.id = order_line_items.order_id",
+			wantErr: false,
+		},
+		{
+			name:    "Valid select with where",
+			sql:     "SELECT name FROM customers WHERE id = 1",
+			wantErr: false,
+		},
+		{
+			name:    "Blocked mutation: INSERT",
+			sql:     "INSERT INTO orders (id) VALUES ('1')",
+			wantErr: true,
+		},
+		{
+			name:    "Blocked mutation: DROP",
+			sql:     "DROP TABLE orders",
+			wantErr: true,
+		},
+		{
+			name:    "Restricted table: users",
+			sql:     "SELECT * FROM users",
+			wantErr: true,
+		},
+		{
+			name:    "Restricted table: app_configs",
+			sql:     "SELECT * FROM app_configs",
+			wantErr: true,
+		},
+		{
+			name:    "Restricted table in JOIN",
+			sql:     "SELECT * FROM orders JOIN users ON orders.customer_name = users.username",
+			wantErr: true,
+		},
+		{
+			name:    "Case insensitivity check",
+			sql:     "select * from ORDERS",
+			wantErr: false,
+		},
+		{
+			name:    "Schema prefix handling",
+			sql:     "SELECT * FROM public.orders",
+			wantErr: false,
+		},
+		{
+			name:    "Unauthorized table with schema prefix",
+			sql:     "SELECT * FROM public.users",
+			wantErr: true,
+		},
+		{
+			name:    "Non-SELECT query",
+			sql:     "WITH t AS (SELECT 1) SELECT * FROM t",
+			wantErr: true,
+		},
+		{
+			name:    "Comma separated tables: Valid",
+			sql:     "SELECT * FROM orders, order_line_items WHERE orders.id = order_line_items.order_id",
+			wantErr: false,
+		},
+		{
+			name:    "Comma separated tables: One Invalid",
+			sql:     "SELECT * FROM orders, users",
+			wantErr: true,
+		},
+		{
+			name:    "Table aliases: Valid",
+			sql:     "SELECT o.id FROM orders o WHERE o.total_price > 100",
+			wantErr: false,
+		},
+		{
+			name:    "Table aliases: Invalid",
+			sql:     "SELECT u.id FROM users u",
+			wantErr: true,
+		},
+		{
+			name:    "Subquery: Restricted",
+			sql:     "SELECT * FROM (SELECT * FROM orders) as t",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := guard.IsSafe(tt.sql); (err != nil) != tt.wantErr {
+				t.Errorf("QueryGuard.IsSafe() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestQueryGuard_IsTableAllowed(t *testing.T) {
+	guard := NewQueryGuard()
+
+	tests := []struct {
+		tableName string
+		want      bool
+	}{
+		{"orders", true},
+		{"ORDERS", true},
+		{"users", false},
+		{"app_configs", false},
+		{"public.orders", true},
+		{"public.users", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tableName, func(t *testing.T) {
+			if got := guard.IsTableAllowed(tt.tableName); got != tt.want {
+				t.Errorf("QueryGuard.IsTableAllowed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The AI QueryGuard previously only blocked mutation keywords, allowing AI-generated raw queries to discover and exfiltrate data from sensitive tables like `users` (containing password hashes) and `app_configs` (containing system secrets).
🎯 **Impact:** Potential exfiltration of administrator credentials or external service API keys via AI analysis tools.
🔧 **Fix:** 
1.  **Strict Allowlist:** Defined a hardcoded map of permitted tables for AI analysis.
2.  **Robust Validation:** Replaced the simple regex check with a multi-clause extractor that handles `FROM` and `JOIN` keywords, comma-separated table lists, and table aliases.
3.  **Subquery Restriction:** Blocked subqueries in AI queries as a defense-in-depth measure against complex bypasses.
4.  **Metadata Filtering:** Updated `AIReadRepository` to filter the output of `ListTables` and validate `DescribeTable` requests against the same allowlist.
✅ **Verification:** 
- Created `backend/internal/repository/query_guard_test.go` with 17 test cases covering valid queries, mutation attempts, restricted tables, aliases, and comma-separated bypass attempts.
- Verified all backend tests pass (`go test ./...`).

---
*PR created automatically by Jules for task [7793812385093304853](https://jules.google.com/task/7793812385093304853) started by @millennialperfumer-tech*