### PR TITLE
🛡️ Sentinel: [security improvement] Fix timing attack vulnerabilities in sensitive comparisons

### DIFF
--- a/backend/internal/handler/marketing_webhook_handler.go
+++ b/backend/internal/handler/marketing_webhook_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"mi-tech/internal/config"
 	"mi-tech/internal/marketing"
@@ -43,7 +44,7 @@ func (h *MarketingWebhookHandler) verifyWebhook(w http.ResponseWriter, r *http.R
 
 	expectedToken := h.settings.GetMetaMarketingWebhookVerifyToken()
 
-	if mode == "subscribe" && token == expectedToken {
+	if mode == "subscribe" && subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1 {
 		fmt.Printf("Meta Marketing Webhook verified successfully!\n")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(challenge))

--- a/backend/internal/handler/webhook_handler.go
+++ b/backend/internal/handler/webhook_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -270,7 +271,7 @@ func (h *WebhookHandler) verifyWebhook(r *http.Request, body []byte) bool {
 	hash.Write(body)
 	expectedHmac := base64.StdEncoding.EncodeToString(hash.Sum(nil))
 
-	isMatch := hmacHeader == expectedHmac
+	isMatch := subtle.ConstantTimeCompare([]byte(hmacHeader), []byte(expectedHmac)) == 1
 	if !isMatch {
 		log.Printf("Webhook HMAC Mismatch!")
 		log.Printf("  Received: %s", hmacHeader)

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"crypto/rand"
+	"crypto/subtle"
 	"io"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -126,7 +127,7 @@ func (s *AuthService) VerifyOTP(username, otp string) (string, error) {
 		return "", errors.New("verification code expired or not found")
 	}
 
-	if user.OTPCode != otp {
+	if subtle.ConstantTimeCompare([]byte(user.OTPCode), []byte(otp)) != 1 {
 		return "", errors.New("invalid verification code")
 	}
 


### PR DESCRIPTION
Mitigates timing side-channel attacks by using crypto/subtle.ConstantTimeCompare for OTP verification, Shopify HMAC validation, and Meta marketing webhook tokens. This ensures that the time taken for these comparisons does not leak information about the secrets being verified.

---
*PR created automatically by Jules for task [14937347031294256742](https://jules.google.com/task/14937347031294256742) started by @millennialperfumer-tech*