### PR TITLE
🛡️ Sentinel: [security improvement] Implement table allowlist in QueryGuard

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `CustomerRepository.List` passed the `sortBy` parameter from user input directly to GORM's `Order()` method without validation.
 **Learning:** ORM methods like GORM's `Order()` often do not parameterize identifiers (like column names) and instead concatenate them into the raw SQL query. This makes them a direct sink for SQL injection if the input is not strictly validated against an allowlist of permitted columns.
 **Prevention:** Always validate dynamic sorting parameters against a hardcoded allowlist map of valid column names before passing them to the database query layer.
+
+## 2026-03-31 - [Fragility of Regex-based SQL Validation]
+**Vulnerability:** Potential bypass of table allowlist if regex only looks for single identifiers after `FROM` or `JOIN`.
+**Learning:** SQL syntax for data source specification is diverse: it includes comma-separated tables (`FROM a, b`), explicit joins (`JOIN b ON ...`), schema qualification (`"public"."users"`), and subqueries (`FROM (SELECT ...)`). Simple regex patterns (`FROM\s+(\w+)`) are easily bypassed or fail on valid complex queries.
+**Prevention:** When using regex for defense-in-depth SQL validation, ensure the pattern or logic handles comma-joins, aliases, and recursively validates subqueries. A more robust (though heavier) approach would be using a real SQL parser.

--- a/backend/internal/repository/query_guard.go
+++ b/backend/internal/repository/query_guard.go
@@ -6,24 +6,38 @@ import (
 	"strings"
 )
 
-// QueryGuard provides runtime safety by blocking SQL mutation keywords.
+// QueryGuard provides runtime safety by blocking SQL mutation keywords and enforcing a table allowlist.
 // This is a defense-in-depth layer for AI-generated or AI-triggered queries.
 type QueryGuard struct {
 	blockedPatterns *regexp.Regexp
+	fromJoinRegex   *regexp.Regexp
+	allowedTables   map[string]bool
 }
 
 func NewQueryGuard() *QueryGuard {
 	// Pattern blocks common mutation keywords. Case-insensitive.
-	// We use \b for word boundaries to avoid blocking things like "orders" (contains "order").
-	// Removed REPLACE because it's a common SELECT function.
-	// Removed COMMENT because it triggers on SQL comments.
-	pattern := `(?i)\b(INSERT|UPDATE|DELETE|DROP|ALTER|TRUNCATE|CREATE|GRANT|REVOKE|EXEC|ATTACH|DETACH|MERGE|UPSERT|RENAME)\b`
+	mutationPattern := `(?i)\b(INSERT|UPDATE|DELETE|DROP|ALTER|TRUNCATE|CREATE|GRANT|REVOKE|EXEC|ATTACH|DETACH|MERGE|UPSERT|RENAME)\b`
+
+	// Regex to find the start of FROM or JOIN clauses.
+	fromJoinPattern := `(?i)\b(FROM|JOIN)\s+`
+
+	allowed := map[string]bool{
+		"orders":                true,
+		"customers":             true,
+		"inventory_items":       true,
+		"order_line_items":      true,
+		"manufacturing_records": true,
+		"oil_inventory":         true,
+	}
+
 	return &QueryGuard{
-		blockedPatterns: regexp.MustCompile(pattern),
+		blockedPatterns: regexp.MustCompile(mutationPattern),
+		fromJoinRegex:   regexp.MustCompile(fromJoinPattern),
+		allowedTables:   allowed,
 	}
 }
 
-// IsSafe checks if the SQL string contains any blocked mutation keywords.
+// IsSafe checks if the SQL string contains any blocked mutation keywords and only accesses allowed tables.
 func (g *QueryGuard) IsSafe(sql string) error {
 	// Normalize whitespace
 	normalized := strings.TrimSpace(strings.Join(strings.Fields(sql), " "))
@@ -33,13 +47,93 @@ func (g *QueryGuard) IsSafe(sql string) error {
 		return fmt.Errorf("SECURITY ALERT: only SELECT queries are allowed")
 	}
 
+	// Check for mutation keywords
 	if g.blockedPatterns.MatchString(normalized) {
-		// Log the first 100 characters of the blocked query for debugging
 		snippet := normalized
 		if len(snippet) > 100 {
 			snippet = snippet[:100] + "..."
 		}
 		return fmt.Errorf("SECURITY ALERT: mutation keyword detected in AI query: %s", snippet)
+	}
+
+	// Check table allowlist
+	// Find all occurrences of FROM/JOIN
+	indices := g.fromJoinRegex.FindAllStringIndex(normalized, -1)
+	for _, idx := range indices {
+		// content starts after FROM/JOIN
+		content := normalized[idx[1]:]
+
+		// Stop at the next keyword
+		stopKeywords := []string{" WHERE ", " GROUP ", " ORDER ", " LIMIT ", " OFFSET ", " ON ", " USING ", " HAVING ", " WINDOW ", " FOR ", " LOCK ", " JOIN ", " FROM "}
+		upperContent := " " + strings.ToUpper(content) + " "
+		earliestStop := len(content)
+
+		for _, sk := range stopKeywords {
+			if stopIdx := strings.Index(upperContent, sk); stopIdx != -1 {
+				if stopIdx < earliestStop {
+					earliestStop = stopIdx
+				}
+			}
+		}
+
+		tablePart := content[:earliestStop]
+
+		// Split by comma for multiple tables in FROM
+		tables := strings.Split(tablePart, ",")
+		for _, t := range tables {
+			t = strings.TrimSpace(t)
+			if t == "" {
+				continue
+			}
+
+			// Table name is the first word (handles aliases)
+			tableNameWithSchema := strings.Fields(t)[0]
+
+			// Handle schema qualification and quotes
+			parts := strings.Split(tableNameWithSchema, ".")
+			tableName := parts[len(parts)-1]
+			tableName = strings.Trim(tableName, `"'`)
+			tableName = strings.ToLower(tableName)
+
+			if !g.allowedTables[tableName] {
+				return fmt.Errorf("SECURITY ALERT: access to table '%s' is not allowed", tableName)
+			}
+		}
+	}
+
+	// Also check for subqueries by recursively calling IsSafe on content inside parentheses
+	content := normalized
+	for {
+		start := strings.Index(strings.ToUpper(content), "(SELECT ")
+		if start == -1 {
+			break
+		}
+
+		// Find matching closing parenthesis
+		bracketCount := 0
+		end := -1
+		for i := start; i < len(content); i++ {
+			if content[i] == '(' {
+				bracketCount++
+			} else if content[i] == ')' {
+				bracketCount--
+				if bracketCount == 0 {
+					end = i
+					break
+				}
+			}
+		}
+
+		if end != -1 {
+			subquery := content[start+1 : end]
+			if err := g.IsSafe(subquery); err != nil {
+				return err
+			}
+			// Continue after this subquery
+			content = content[end+1:]
+		} else {
+			break
+		}
 	}
 	
 	return nil

--- a/backend/internal/repository/query_guard_test.go
+++ b/backend/internal/repository/query_guard_test.go
@@ -1,0 +1,79 @@
+package repository
+
+import (
+	"testing"
+)
+
+func TestQueryGuard_TableAllowlist(t *testing.T) {
+	g := NewQueryGuard()
+
+	tests := []struct {
+		name    string
+		sql     string
+		wantErr bool
+	}{
+		{
+			name:    "Allowed table",
+			sql:     "SELECT * FROM orders",
+			wantErr: false,
+		},
+		{
+			name:    "Blocked table - users",
+			sql:     "SELECT * FROM users",
+			wantErr: true,
+		},
+		{
+			name:    "Blocked table - app_configs",
+			sql:     "SELECT * FROM app_configs",
+			wantErr: true,
+		},
+		{
+			name:    "Complex query allowed",
+			sql:     "SELECT o.id, li.title FROM orders o JOIN order_line_items li ON o.id = li.order_id",
+			wantErr: false,
+		},
+		{
+			name:    "Complex query blocked",
+			sql:     "SELECT * FROM orders JOIN users ON orders.user_id = users.id",
+			wantErr: true,
+		},
+		{
+			name:    "Blocked table - users with aliases",
+			sql:     "SELECT * FROM users u",
+			wantErr: true,
+		},
+		{
+			name:    "Subquery blocked",
+			sql:     "SELECT * FROM (SELECT * FROM users) as t",
+			wantErr: true,
+		},
+		{
+			name:    "Comma separated tables allowed",
+			sql:     "SELECT * FROM orders, customers",
+			wantErr: false,
+		},
+		{
+			name:    "Comma separated tables blocked",
+			sql:     "SELECT * FROM orders, users",
+			wantErr: true,
+		},
+		{
+			name:    "Quoted schema and table allowed",
+			sql:     `SELECT * FROM "public"."orders"`,
+			wantErr: false,
+		},
+		{
+			name:    "Quoted schema and table blocked",
+			sql:     `SELECT * FROM "public"."users"`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := g.IsSafe(tt.sql); (err != nil) != tt.wantErr {
+				t.Errorf("IsSafe() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implemented a robust table allowlist in `QueryGuard` to prevent AI-generated or AI-triggered SQL queries from accessing sensitive tables like `users` or `app_configs`. The implementation uses iterative scanning of `FROM` and `JOIN` clauses and recursive subquery validation to ensure all data sources in a query are within the permitted allowlist.

---
*PR created automatically by Jules for task [11368428727918585185](https://jules.google.com/task/11368428727918585185) started by @millennialperfumer-tech*