### PR TITLE
🛡️ Sentinel: [HIGH] Fix CORS wildcard credential vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** `CustomerRepository.List` passed the `sortBy` parameter from user input directly to GORM's `Order()` method without validation.
 **Learning:** ORM methods like GORM's `Order()` often do not parameterize identifiers (like column names) and instead concatenate them into the raw SQL query. This makes them a direct sink for SQL injection if the input is not strictly validated against an allowlist of permitted columns.
 **Prevention:** Always validate dynamic sorting parameters against a hardcoded allowlist map of valid column names before passing them to the database query layer.
+
+## 2026-06-05 - [Secure CORS Wildcard Handling]
+**Vulnerability:** Permissive CORS wildcard handling reflected the `Origin` header and allowed credentials even when a wildcard was specified in the configuration.
+**Learning:** Browsers prohibit the use of `Access-Control-Allow-Credentials: true` when `Access-Control-Allow-Origin` is set to `*`. Reflecting the origin while using a wildcard configuration bypasses this protection, effectively allowing any site to make authenticated requests.
+**Prevention:** When a wildcard is matched in the allowed origins list, explicitly set `Access-Control-Allow-Origin: *` and omit the `Access-Control-Allow-Credentials` header.

--- a/backend/internal/server/cors_security_test.go
+++ b/backend/internal/server/cors_security_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestCORSMiddleware_Wildcard(t *testing.T) {
+	os.Setenv("ALLOWED_ORIGINS", "*")
+	defer os.Unsetenv("ALLOWED_ORIGINS")
+
+	handler := CORSMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/api/health", nil)
+	req.Header.Set("Origin", "http://evil.com")
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	originHeader := res.Header().Get("Access-Control-Allow-Origin")
+	if originHeader != "*" {
+		t.Errorf("Expected Origin header '*', got %q", originHeader)
+	}
+
+	credsHeader := res.Header().Get("Access-Control-Allow-Credentials")
+	if credsHeader != "" {
+		t.Errorf("Expected Access-Control-Allow-Credentials to be empty for wildcard, got %q", credsHeader)
+	}
+}
+
+func TestCORSMiddleware_Specific(t *testing.T) {
+	os.Setenv("ALLOWED_ORIGINS", "http://trusted.com")
+	defer os.Unsetenv("ALLOWED_ORIGINS")
+
+	handler := CORSMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/api/health", nil)
+	req.Header.Set("Origin", "http://trusted.com")
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	originHeader := res.Header().Get("Access-Control-Allow-Origin")
+	if originHeader != "http://trusted.com" {
+		t.Errorf("Expected Origin header 'http://trusted.com', got %q", originHeader)
+	}
+
+	credsHeader := res.Header().Get("Access-Control-Allow-Credentials")
+	if credsHeader != "true" {
+		t.Errorf("Expected Access-Control-Allow-Credentials to be 'true' for specific origin, got %q", credsHeader)
+	}
+}

--- a/backend/internal/server/middleware.go
+++ b/backend/internal/server/middleware.go
@@ -28,6 +28,7 @@ func CORSMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		rawOrigin := r.Header.Get("Origin")
 		origin := normalizeOrigin(rawOrigin)
 		isAllowed := false
+		isWildcardMatch := false
 
 		// Always set Vary: Origin to handle caching behind proxies/CDNs
 		w.Header().Add("Vary", "Origin")
@@ -39,7 +40,11 @@ func CORSMiddleware(next http.HandlerFunc) http.HandlerFunc {
 			allowedOrigins := strings.Split(allowedOriginsEnv, ",")
 			for _, allowed := range allowedOrigins {
 				trimmed := normalizeOrigin(allowed)
-				if trimmed == "*" || origin == trimmed {
+				if trimmed == "*" {
+					isAllowed = true
+					isWildcardMatch = true
+					break
+				} else if origin == trimmed {
 					isAllowed = true
 					break
 				}
@@ -48,9 +53,15 @@ func CORSMiddleware(next http.HandlerFunc) http.HandlerFunc {
 
 		if isAllowed {
 			if rawOrigin != "" {
-				// Use the actual origin for the allow header to support multiple origins with credentials
-				w.Header().Set("Access-Control-Allow-Origin", rawOrigin)
-				w.Header().Set("Access-Control-Allow-Credentials", "true")
+				if isWildcardMatch {
+					// Security: If wildcard is used, set Access-Control-Allow-Origin to *
+					// and do NOT set Access-Control-Allow-Credentials to true.
+					w.Header().Set("Access-Control-Allow-Origin", "*")
+				} else {
+					// Use the actual origin for the allow header to support multiple origins with credentials
+					w.Header().Set("Access-Control-Allow-Origin", rawOrigin)
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
+				}
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, PATCH")
 				w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, X-Requested-With, X-Amz-Date, X-Api-Key, X-Amz-Security-Token, X-Forwarded-For, X-Real-IP, Origin, Access-Control-Request-Method, Access-Control-Request-Headers")
 				w.Header().Set("Access-Control-Max-Age", "86400") // 24 hours


### PR DESCRIPTION
### 🚨 Severity: HIGH
### 💡 Vulnerability: Permissive CORS Configuration with Wildcard (CWE-942)
The `CORSMiddleware` was previously reflecting the `Origin` header and setting `Access-Control-Allow-Credentials: true` even when `ALLOWED_ORIGINS` was configured with a wildcard `*`. This allowed any third-party domain to perform authenticated requests to the API on behalf of a user if the administrator mistakenly used a wildcard for development or convenience.

### 🎯 Impact:
An attacker could host a malicious site that makes authenticated requests (using the user's cookies/session) to the backend API, potentially leading to data theft or unauthorized actions if a user visits the malicious site while logged into the application.

### 🔧 Fix:
Modified `backend/internal/server/middleware.go` to distinguish between wildcard and specific origin matches. 
- For wildcard matches (`*`), it sets `Access-Control-Allow-Origin: *` and omits the `Access-Control-Allow-Credentials` header.
- For specific origin matches, it continues to reflect the origin and allow credentials.

### ✅ Verification:
- Added `backend/internal/server/cors_security_test.go` with targeted test cases for wildcard and specific origin scenarios.
- Ran all backend tests: `cd backend && go test ./...`
- Verified that `TestCORSMiddleware_Wildcard` and `TestCORSMiddleware_Specific` pass.

---
*PR created automatically by Jules for task [18045690009133194198](https://jules.google.com/task/18045690009133194198) started by @millennialperfumer-tech*