### PR TITLE
🛡️ Sentinel: [HIGH] Fix Open Redirect in tracking endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -16,3 +16,8 @@
 **Vulnerability:** The `MarketingWebhookHandler.handleNotification` endpoint did not verify the `X-Hub-Signature-256` header, allowing unauthenticated attackers to spoof requests.
 **Learning:** For endpoints handling payloads from external systems, validation must happen implicitly via signature verification before any business logic executes. Missing these checks leaves the endpoints wide open.
 **Prevention:** Implement HMAC verification for all external webhooks. Specifically, utilize `io.LimitReader` (for DoS protection), restore the body via `io.NopCloser(bytes.NewBuffer(body))`, and enforce strict string comparison logic using `hmac.Equal` to defend against timing attacks.
+
+## 2026-06-13 - [Open Redirect in Tracking System]
+**Vulnerability:** The tracking link redirect handler blindly redirected users to whatever `trackingURL` was stored in the database without any domain validation.
+**Learning:** Even internal data sources (like a database) can contain unvalidated or poisoned URLs. Blindly redirecting to a stored URL acts as an Open Redirect. However, implementing a strict single-domain allowlist can break legitimate multi-provider integrations (e.g. tracking links for various couriers like Delhivery, Shiprocket).
+**Prevention:** Always parse the destination URL and validate its hostname against a broad, yet strict allowlist of trusted root domains (including their subdomains) corresponding to the business's actual integrated partners to prevent attackers from redirecting to arbitrary malicious domains.

--- a/backend/internal/handler/redirect_handler.go
+++ b/backend/internal/handler/redirect_handler.go
@@ -3,8 +3,43 @@ package handler
 import (
 	"mi-tech/internal/repository"
 	"net/http"
+	"net/url"
 	"strings"
 )
+
+// allowedTrackingDomains contains a list of allowed root domains for courier tracking links
+// to prevent Open Redirect vulnerabilities while supporting major providers.
+var allowedTrackingDomains = map[string]bool{
+	"tracking.com":     true,
+	"delhivery.com":    true,
+	"shiprocket.in":    true,
+	"bluedart.com":     true,
+	"dhl.com":          true,
+	"fedex.com":        true,
+	"ups.com":          true,
+	"usps.com":         true,
+	"amazon.in":        true,
+	"amazon.com":       true,
+	"ecomexpress.in":   true,
+	"xpressbees.com":   true,
+	"indiapost.gov.in": true,
+}
+
+// isAllowedDomain checks if the parsed hostname matches an allowed domain or its subdomains.
+func isAllowedDomain(hostname string) bool {
+	hostname = strings.ToLower(hostname)
+	if allowedTrackingDomains[hostname] {
+		return true
+	}
+
+	// Check for subdomains (e.g., track.delhivery.com)
+	for domain := range allowedTrackingDomains {
+		if strings.HasSuffix(hostname, "."+domain) {
+			return true
+		}
+	}
+	return false
+}
 
 type RedirectHandler struct {
 	orderRepo repository.OrderRepository
@@ -49,6 +84,13 @@ func (h *RedirectHandler) RedirectTracking(w http.ResponseWriter, r *http.Reques
 	// Double check protocol
 	if !strings.HasPrefix(trackingURL, "http") {
 		trackingURL = "https://" + trackingURL
+	}
+
+	// Validate tracking URL domain to prevent Open Redirect
+	parsedURL, err := url.Parse(trackingURL)
+	if err != nil || !isAllowedDomain(parsedURL.Hostname()) {
+		http.Redirect(w, r, "https://millennialperfumer.com", http.StatusTemporaryRedirect)
+		return
 	}
 
 	http.Redirect(w, r, trackingURL, http.StatusTemporaryRedirect)


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The `/t/{id}` endpoint blindly redirected requests using the `trackingURL` stored in the database without any structural or domain validation, acting as a stored Open Redirect.
🎯 **Impact**: Attackers could poison the database tracking URL (or exploit downstream flaws) to construct phishing links using the application's domain to forward victims to malicious sites.
🔧 **Fix**: Implemented strict domain validation in `backend/internal/handler/redirect_handler.go`. Using `net/url`, the hostname is verified against a broad but strict allowlist of major global and Indian couriers (including subdomains) before redirection.
✅ **Verification**: Verified using `go test ./...` in the `backend` directory.

Learnings also added to `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [9941398039213654136](https://jules.google.com/task/9941398039213654136) started by @millennialperfumer-tech*