### PR TITLE
🚀 Catalyst: Add VIP Customer Segmentation Growth Proposal

### DIFF
--- a/.jules/catalyst.md
+++ b/.jules/catalyst.md
@@ -17,3 +17,12 @@
 * **Business Growth & Profit Impact**: Recovering abandoned carts is one of the highest leverage ways to increase conversion rates and AOV. By capturing draft orders from Shopify and directly pushing them into the MI-Tech SMM hub, we can implement an automated or semi-automated WhatsApp sequence. Even a 10-15% recovery rate on abandoned carts will directly and significantly contribute to hitting the 3 Lakhs/month revenue target with very little additional marginal cost.
 * **Technical Complexity**: Medium
 * **Description**: Implement a new backend module that listens for Shopify 'checkout/update' and 'checkout/create' webhooks (or periodically polls draft orders). The system will map these to a new "AbandonedCart" entity. Integrate this with the SMM hub to automatically dispatch a WhatsApp template message (e.g., "Hi [Name], you left [Item] in your cart. Need help?") 30-60 minutes after abandonment, complete with a direct checkout link.
+
+### [IDE-003] VIP Customer Segmentation & Automated Retention Loop
+* **Added On**: 2024-06-17
+* **Target Audience**: Store Admins, End Customers
+* **3L Growth Vector**: Increase Purchase Frequency (LTV Boost)
+* **Customer Value Proposition**: High-value customers feel recognized and rewarded. They receive exclusive early access, targeted bundles, or special gifts via WhatsApp, cementing their loyalty and enhancing their premium brand experience.
+* **Business Growth & Profit Impact**: By identifying and isolating the top 10% of customers (VIPs based on `TotalSpent` and `TotalOrders`), we can run highly targeted retention campaigns via the SMM hub. VIPs are significantly more likely to convert on higher-margin upsells and repeat purchases without relying on paid ads, driving net profit margins and accelerating the path to 3L/month.
+* **Technical Complexity**: Medium
+* **Description**: Implement a scheduled background job in the backend that scans the `customers` table for individuals exceeding defined thresholds for `TotalSpent` and `TotalOrders`. These customers are automatically tagged as 'VIP'. Integrate this tag with the `communication` (SMM) module to allow admins to broadcast exclusive WhatsApp templates (e.g., new product drops, personalized clone recommendations) specifically to this high-value segment.

--- a/backend/internal/domain/b2b/entity/invoice.go
+++ b/backend/internal/domain/b2b/entity/invoice.go
@@ -20,15 +20,15 @@ type B2BInvoice struct {
 	Subject         *string    `gorm:"column:subject" json:"subject"`
 
 	// Customer snapshot fields (immutable historical details)
-	CustomerID        *int64  `gorm:"column:customer_id" json:"customer_id"`
-	CustomerGSTIN     string  `gorm:"column:customer_gstin" json:"customer_gstin"`
-	CustomerName      string  `gorm:"column:customer_name" json:"customer_name"`
-	CustomerEmail     *string `gorm:"column:customer_email" json:"customer_email"`
-	CustomerPhone     *string `gorm:"column:customer_phone" json:"customer_phone"`
-	CustomerState     string  `gorm:"column:customer_state" json:"customer_state"`
-	CustomerStateCode string  `gorm:"column:customer_state_code" json:"customer_state_code"`
-	CustomerAddress   string  `gorm:"column:customer_address" json:"customer_address"`
-	CustomerShippingAddress string `gorm:"column:customer_shipping_address" json:"customer_shipping_address"`
+	CustomerID              *int64  `gorm:"column:customer_id" json:"customer_id"`
+	CustomerGSTIN           string  `gorm:"column:customer_gstin" json:"customer_gstin"`
+	CustomerName            string  `gorm:"column:customer_name" json:"customer_name"`
+	CustomerEmail           *string `gorm:"column:customer_email" json:"customer_email"`
+	CustomerPhone           *string `gorm:"column:customer_phone" json:"customer_phone"`
+	CustomerState           string  `gorm:"column:customer_state" json:"customer_state"`
+	CustomerStateCode       string  `gorm:"column:customer_state_code" json:"customer_state_code"`
+	CustomerAddress         string  `gorm:"column:customer_address" json:"customer_address"`
+	CustomerShippingAddress string  `gorm:"column:customer_shipping_address" json:"customer_shipping_address"`
 
 	// Seller details snapshot
 	SellerGSTIN     string `gorm:"column:seller_gstin" json:"seller_gstin"`
@@ -67,12 +67,12 @@ type B2BInvoice struct {
 	PaymentDate   *time.Time `gorm:"column:payment_date" json:"payment_date"`
 	PaymentMethod *string    `gorm:"column:payment_method" json:"payment_method"`
 
-	CustomerNotes *string   `gorm:"column:customer_notes" json:"customer_notes"`
-	ProformaID    *int64    `gorm:"column:proforma_id" json:"proforma_id"`
-	AdvanceAdjusted float64 `gorm:"column:advance_adjusted" json:"advance_adjusted"`
-	InventoryDeducted bool `gorm:"column:inventory_deducted;default:false" json:"inventory_deducted"`
-	CreatedAt     time.Time `gorm:"column:created_at;default:NOW()" json:"created_at"`
-	UpdatedAt     time.Time `gorm:"column:updated_at;default:NOW()" json:"updated_at"`
+	CustomerNotes     *string   `gorm:"column:customer_notes" json:"customer_notes"`
+	ProformaID        *int64    `gorm:"column:proforma_id" json:"proforma_id"`
+	AdvanceAdjusted   float64   `gorm:"column:advance_adjusted" json:"advance_adjusted"`
+	InventoryDeducted bool      `gorm:"column:inventory_deducted;default:false" json:"inventory_deducted"`
+	CreatedAt         time.Time `gorm:"column:created_at;default:NOW()" json:"created_at"`
+	UpdatedAt         time.Time `gorm:"column:updated_at;default:NOW()" json:"updated_at"`
 
 	Items []B2BInvoiceItem `gorm:"foreignKey:InvoiceID" json:"items"`
 }
@@ -163,4 +163,3 @@ func parseFlexDate(s string) (time.Time, error) {
 	}
 	return time.Time{}, fmt.Errorf("invalid date format: %q", s)
 }
-

--- a/backend/internal/domain/b2b/entity/note.go
+++ b/backend/internal/domain/b2b/entity/note.go
@@ -6,14 +6,14 @@ import (
 
 // B2BCreditNote represents a B2B Credit Note
 type B2BCreditNote struct {
-	ID                 int64      `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
-	CreditNoteNumber   *string    `gorm:"column:credit_note_number;unique" json:"credit_note_number"`
-	CreditNoteSequence *int       `gorm:"column:credit_note_sequence" json:"credit_note_sequence"`
-	FinancialYear      *string    `gorm:"column:financial_year" json:"financial_year"`
-	InvoiceID          *int64     `gorm:"column:invoice_id" json:"invoice_id"`
-	InvoiceNumber      *string    `gorm:"column:invoice_number" json:"invoice_number"`
-	NoteDate           time.Time  `gorm:"column:note_date" json:"note_date"`
-	Reason             *string    `gorm:"column:reason" json:"reason"`
+	ID                 int64     `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	CreditNoteNumber   *string   `gorm:"column:credit_note_number;unique" json:"credit_note_number"`
+	CreditNoteSequence *int      `gorm:"column:credit_note_sequence" json:"credit_note_sequence"`
+	FinancialYear      *string   `gorm:"column:financial_year" json:"financial_year"`
+	InvoiceID          *int64    `gorm:"column:invoice_id" json:"invoice_id"`
+	InvoiceNumber      *string   `gorm:"column:invoice_number" json:"invoice_number"`
+	NoteDate           time.Time `gorm:"column:note_date" json:"note_date"`
+	Reason             *string   `gorm:"column:reason" json:"reason"`
 
 	// Customer snapshot
 	CustomerID        *int64  `gorm:"column:customer_id" json:"customer_id"`
@@ -79,14 +79,14 @@ func (B2BCreditNoteItem) TableName() string {
 
 // B2BDebitNote represents a B2B Debit Note
 type B2BDebitNote struct {
-	ID                int64      `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
-	DebitNoteNumber   *string    `gorm:"column:debit_note_number;unique" json:"debit_note_number"`
-	DebitNoteSequence *int       `gorm:"column:debit_note_sequence" json:"debit_note_sequence"`
-	FinancialYear     *string    `gorm:"column:financial_year" json:"financial_year"`
-	InvoiceID         *int64     `gorm:"column:invoice_id" json:"invoice_id"`
-	InvoiceNumber     *string    `gorm:"column:invoice_number" json:"invoice_number"`
-	NoteDate          time.Time  `gorm:"column:note_date" json:"note_date"`
-	Reason            *string    `gorm:"column:reason" json:"reason"`
+	ID                int64     `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	DebitNoteNumber   *string   `gorm:"column:debit_note_number;unique" json:"debit_note_number"`
+	DebitNoteSequence *int      `gorm:"column:debit_note_sequence" json:"debit_note_sequence"`
+	FinancialYear     *string   `gorm:"column:financial_year" json:"financial_year"`
+	InvoiceID         *int64    `gorm:"column:invoice_id" json:"invoice_id"`
+	InvoiceNumber     *string   `gorm:"column:invoice_number" json:"invoice_number"`
+	NoteDate          time.Time `gorm:"column:note_date" json:"note_date"`
+	Reason            *string   `gorm:"column:reason" json:"reason"`
 
 	// Customer snapshot
 	CustomerID        *int64  `gorm:"column:customer_id" json:"customer_id"`

--- a/backend/internal/domain/b2b/entity/proforma.go
+++ b/backend/internal/domain/b2b/entity/proforma.go
@@ -7,26 +7,26 @@ import (
 
 // B2BProformaInvoice represents a commercial proforma invoice
 type B2BProformaInvoice struct {
-	ID               int64                  `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
-	ProformaNumber   *string                `gorm:"column:proforma_number;unique" json:"proforma_number"`
-	ProformaSequence *int                   `gorm:"column:proforma_sequence" json:"proforma_sequence"`
-	FinancialYear    *string                `gorm:"column:financial_year" json:"financial_year"`
-	NoteDate         time.Time              `gorm:"column:note_date" json:"note_date"`
-	ValidUntil       *time.Time             `gorm:"column:valid_until" json:"valid_until"`
-	Status           string                 `gorm:"column:status;default:DRAFT" json:"status"` // DRAFT, SENT, ACCEPTED, CONVERTED_TO_INVOICE, REJECTED, EXPIRED, CANCELLED
-	RevisionNumber   int                    `gorm:"column:revision_number;default:1" json:"revision_number"`
-	ParentProformaID *int64                 `gorm:"column:parent_proforma_id" json:"parent_proforma_id"`
+	ID               int64      `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	ProformaNumber   *string    `gorm:"column:proforma_number;unique" json:"proforma_number"`
+	ProformaSequence *int       `gorm:"column:proforma_sequence" json:"proforma_sequence"`
+	FinancialYear    *string    `gorm:"column:financial_year" json:"financial_year"`
+	NoteDate         time.Time  `gorm:"column:note_date" json:"note_date"`
+	ValidUntil       *time.Time `gorm:"column:valid_until" json:"valid_until"`
+	Status           string     `gorm:"column:status;default:DRAFT" json:"status"` // DRAFT, SENT, ACCEPTED, CONVERTED_TO_INVOICE, REJECTED, EXPIRED, CANCELLED
+	RevisionNumber   int        `gorm:"column:revision_number;default:1" json:"revision_number"`
+	ParentProformaID *int64     `gorm:"column:parent_proforma_id" json:"parent_proforma_id"`
 
 	// Customer snapshot fields (immutable historical details)
-	CustomerID        *int64  `gorm:"column:customer_id" json:"customer_id"`
-	CustomerGSTIN     string  `gorm:"column:customer_gstin" json:"customer_gstin"`
-	CustomerName      string  `gorm:"column:customer_name" json:"customer_name"`
-	CustomerEmail     *string `gorm:"column:customer_email" json:"customer_email"`
-	CustomerPhone     *string `gorm:"column:customer_phone" json:"customer_phone"`
-	CustomerState     string  `gorm:"column:customer_state" json:"customer_state"`
-	CustomerStateCode string  `gorm:"column:customer_state_code" json:"customer_state_code"`
-	CustomerAddress   string  `gorm:"column:customer_address" json:"customer_address"`
-	CustomerShippingAddress string `gorm:"column:customer_shipping_address" json:"customer_shipping_address"`
+	CustomerID              *int64  `gorm:"column:customer_id" json:"customer_id"`
+	CustomerGSTIN           string  `gorm:"column:customer_gstin" json:"customer_gstin"`
+	CustomerName            string  `gorm:"column:customer_name" json:"customer_name"`
+	CustomerEmail           *string `gorm:"column:customer_email" json:"customer_email"`
+	CustomerPhone           *string `gorm:"column:customer_phone" json:"customer_phone"`
+	CustomerState           string  `gorm:"column:customer_state" json:"customer_state"`
+	CustomerStateCode       string  `gorm:"column:customer_state_code" json:"customer_state_code"`
+	CustomerAddress         string  `gorm:"column:customer_address" json:"customer_address"`
+	CustomerShippingAddress string  `gorm:"column:customer_shipping_address" json:"customer_shipping_address"`
 
 	// Seller details snapshot
 	SellerGSTIN     string `gorm:"column:seller_gstin" json:"seller_gstin"`
@@ -115,4 +115,3 @@ func (pf *B2BProformaInvoice) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
-

--- a/backend/internal/domain/b2b/handler/b2b_handler.go
+++ b/backend/internal/domain/b2b/handler/b2b_handler.go
@@ -817,4 +817,3 @@ func (h *B2BHandler) CheckExpiredProformas(w http.ResponseWriter, r *http.Reques
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{"status": "success", "expired_count": count})
 }
-

--- a/backend/internal/domain/b2b/repository/b2b_repository.go
+++ b/backend/internal/domain/b2b/repository/b2b_repository.go
@@ -143,7 +143,7 @@ func (r *gormB2BRepository) GetInvoiceByID(id int64) (entity.B2BInvoice, error) 
 
 func (r *gormB2BRepository) syncToOrdersTable(tx *gorm.DB, inv *entity.B2BInvoice) error {
 	extID := fmt.Sprintf("B2B-%d", inv.ID)
-	
+
 	// Check if order already exists
 	var orderID int64
 	err := tx.Table("orders").Where("source_id = ? AND external_order_id = ?", "b2b", extID).Pluck("id", &orderID).Error
@@ -161,7 +161,7 @@ func (r *gormB2BRepository) syncToOrdersTable(tx *gorm.DB, inv *entity.B2BInvoic
 	}
 
 	totalTax := inv.CGSTAmount + inv.SGSTAmount + inv.IGSTAmount
-	
+
 	orderNumber := extID
 	if inv.InvoiceNumber != nil && *inv.InvoiceNumber != "" {
 		orderNumber = *inv.InvoiceNumber
@@ -174,7 +174,7 @@ func (r *gormB2BRepository) syncToOrdersTable(tx *gorm.DB, inv *entity.B2BInvoic
 
 	orderData := map[string]interface{}{
 		"source_id":          "b2b",
-		"external_order_id":   extID,
+		"external_order_id":  extID,
 		"order_number":       orderNumber,
 		"invoice_number":     invoiceNumber,
 		"total_price":        inv.TotalPrice,
@@ -223,7 +223,7 @@ func (r *gormB2BRepository) syncToOrdersTable(tx *gorm.DB, inv *entity.B2BInvoic
 			if item.ID == 0 {
 				liID = fmt.Sprintf("b2b-%d-idx-%d", inv.ID, i)
 			}
-			
+
 			var productIDStr *string
 			if item.ProductID != nil {
 				s := fmt.Sprintf("%d", *item.ProductID)
@@ -650,5 +650,3 @@ func (r *gormB2BRepository) GetNextProformaSequenceForFY(fy string) (int, error)
 		Count(&count).Error
 	return int(count) + 1, err
 }
-
-

--- a/backend/internal/domain/b2b/service/proforma_b2b.go
+++ b/backend/internal/domain/b2b/service/proforma_b2b.go
@@ -113,14 +113,14 @@ func (s *B2BService) IssueProforma(id int64) (*entity.B2BProformaInvoice, error)
 
 		// Calculate number sequence
 		fy := helper.GetFinancialYear(pf.NoteDate)
-		
+
 		if pf.ParentProformaID != nil {
 			// It's a revision! Use parent's number and sequence with revision suffix
 			var parent entity.B2BProformaInvoice
 			if err := tx.First(&parent, *pf.ParentProformaID).Error; err != nil {
 				return fmt.Errorf("failed to fetch parent proforma: %w", err)
 			}
-			
+
 			parentNum := ""
 			if parent.ProformaNumber != nil {
 				parentNum = *parent.ProformaNumber
@@ -257,36 +257,36 @@ func (s *B2BService) CreateRevision(id int64) (*entity.B2BProformaInvoice, error
 		}
 
 		revision = entity.B2BProformaInvoice{
-			Status:            "DRAFT",
-			RevisionNumber:    int(count) + 1,
-			ParentProformaID:  &parentID,
-			NoteDate:          existing.NoteDate,
-			ValidUntil:        existing.ValidUntil,
-			CustomerID:        existing.CustomerID,
-			CustomerGSTIN:     existing.CustomerGSTIN,
-			CustomerName:      existing.CustomerName,
-			CustomerEmail:     existing.CustomerEmail,
-			CustomerPhone:     existing.CustomerPhone,
-			CustomerState:     existing.CustomerState,
-			CustomerStateCode: existing.CustomerStateCode,
-			CustomerAddress:   existing.CustomerAddress,
+			Status:                  "DRAFT",
+			RevisionNumber:          int(count) + 1,
+			ParentProformaID:        &parentID,
+			NoteDate:                existing.NoteDate,
+			ValidUntil:              existing.ValidUntil,
+			CustomerID:              existing.CustomerID,
+			CustomerGSTIN:           existing.CustomerGSTIN,
+			CustomerName:            existing.CustomerName,
+			CustomerEmail:           existing.CustomerEmail,
+			CustomerPhone:           existing.CustomerPhone,
+			CustomerState:           existing.CustomerState,
+			CustomerStateCode:       existing.CustomerStateCode,
+			CustomerAddress:         existing.CustomerAddress,
 			CustomerShippingAddress: existing.CustomerShippingAddress,
-			SellerGSTIN:       existing.SellerGSTIN,
-			SellerName:        existing.SellerName,
-			SellerState:       existing.SellerState,
-			SellerStateCode:   existing.SellerStateCode,
-			SellerAddress:     existing.SellerAddress,
-			SubtotalPrice:     existing.SubtotalPrice,
-			DiscountPercent:   existing.DiscountPercent,
-			DiscountAmount:    existing.DiscountAmount,
-			CGSTRate:          existing.CGSTRate,
-			CGSTAmount:        existing.CGSTAmount,
-			SGSTRate:          existing.SGSTRate,
-			SGSTAmount:        existing.SGSTAmount,
-			IGSTRate:          existing.IGSTRate,
-			IGSTAmount:        existing.IGSTAmount,
-			TotalPrice:        existing.TotalPrice,
-			AdvancePaid:       existing.AdvancePaid,
+			SellerGSTIN:             existing.SellerGSTIN,
+			SellerName:              existing.SellerName,
+			SellerState:             existing.SellerState,
+			SellerStateCode:         existing.SellerStateCode,
+			SellerAddress:           existing.SellerAddress,
+			SubtotalPrice:           existing.SubtotalPrice,
+			DiscountPercent:         existing.DiscountPercent,
+			DiscountAmount:          existing.DiscountAmount,
+			CGSTRate:                existing.CGSTRate,
+			CGSTAmount:              existing.CGSTAmount,
+			SGSTRate:                existing.SGSTRate,
+			SGSTAmount:              existing.SGSTAmount,
+			IGSTRate:                existing.IGSTRate,
+			IGSTAmount:              existing.IGSTAmount,
+			TotalPrice:              existing.TotalPrice,
+			AdvancePaid:             existing.AdvancePaid,
 		}
 
 		for _, item := range existing.Items {
@@ -338,35 +338,35 @@ func (s *B2BService) ConvertToTaxInvoice(id int64) (*entity.B2BInvoice, error) {
 
 		// Map to B2BInvoice
 		invoice = entity.B2BInvoice{
-			InvoiceDate:       time.Now(),
-			Status:            "DRAFT",
-			PaymentStatus:     "UNPAID",
-			CustomerID:        pf.CustomerID,
-			CustomerGSTIN:     pf.CustomerGSTIN,
-			CustomerName:      pf.CustomerName,
-			CustomerEmail:     pf.CustomerEmail,
-			CustomerPhone:     pf.CustomerPhone,
-			CustomerState:     pf.CustomerState,
-			CustomerStateCode: pf.CustomerStateCode,
-			CustomerAddress:   pf.CustomerAddress,
+			InvoiceDate:             time.Now(),
+			Status:                  "DRAFT",
+			PaymentStatus:           "UNPAID",
+			CustomerID:              pf.CustomerID,
+			CustomerGSTIN:           pf.CustomerGSTIN,
+			CustomerName:            pf.CustomerName,
+			CustomerEmail:           pf.CustomerEmail,
+			CustomerPhone:           pf.CustomerPhone,
+			CustomerState:           pf.CustomerState,
+			CustomerStateCode:       pf.CustomerStateCode,
+			CustomerAddress:         pf.CustomerAddress,
 			CustomerShippingAddress: pf.CustomerShippingAddress,
-			SellerGSTIN:       pf.SellerGSTIN,
-			SellerName:        pf.SellerName,
-			SellerState:       pf.SellerState,
-			SellerStateCode:   pf.SellerStateCode,
-			SellerAddress:     pf.SellerAddress,
-			SubtotalPrice:     pf.SubtotalPrice,
-			DiscountPercent:   pf.DiscountPercent,
-			DiscountAmount:    pf.DiscountAmount,
-			CGSTRate:          pf.CGSTRate,
-			CGSTAmount:        pf.CGSTAmount,
-			SGSTRate:          pf.SGSTRate,
-			SGSTAmount:        pf.SGSTAmount,
-			IGSTRate:          pf.IGSTRate,
-			IGSTAmount:        pf.IGSTAmount,
-			TotalPrice:        pf.TotalPrice,
-			ProformaID:        &pf.ID,
-			AdvanceAdjusted:   pf.AdvancePaid,
+			SellerGSTIN:             pf.SellerGSTIN,
+			SellerName:              pf.SellerName,
+			SellerState:             pf.SellerState,
+			SellerStateCode:         pf.SellerStateCode,
+			SellerAddress:           pf.SellerAddress,
+			SubtotalPrice:           pf.SubtotalPrice,
+			DiscountPercent:         pf.DiscountPercent,
+			DiscountAmount:          pf.DiscountAmount,
+			CGSTRate:                pf.CGSTRate,
+			CGSTAmount:              pf.CGSTAmount,
+			SGSTRate:                pf.SGSTRate,
+			SGSTAmount:              pf.SGSTAmount,
+			IGSTRate:                pf.IGSTRate,
+			IGSTAmount:              pf.IGSTAmount,
+			TotalPrice:              pf.TotalPrice,
+			ProformaID:              &pf.ID,
+			AdvanceAdjusted:         pf.AdvancePaid,
 		}
 
 		// Adjust BalanceAmount and PaymentStatus based on AdvancePaid

--- a/backend/internal/domain/b2b/test/b2b_service_test.go
+++ b/backend/internal/domain/b2b/test/b2b_service_test.go
@@ -299,4 +299,3 @@ func (s *B2BServiceTestSuite) TestInvoiceDeleteCascadesAndSync() {
 func TestB2BServiceSuite(t *testing.T) {
 	suite.Run(t, new(B2BServiceTestSuite))
 }
-

--- a/backend/internal/domain/b2b/test/proforma_test.go
+++ b/backend/internal/domain/b2b/test/proforma_test.go
@@ -120,7 +120,7 @@ func (s *B2BProformaTestSuite) TestProformaLifecycle() {
 	assert.Equal(s.T(), "DRAFT", taxInv.Status)
 	assert.Equal(s.T(), issuedRev.ID, *taxInv.ProformaID)
 	assert.Equal(s.T(), 5000.00, taxInv.AdvanceAdjusted)
-	
+
 	// Total price = 22000 + 18% GST (3960) = 25960.00
 	assert.Equal(s.T(), 25960.00, taxInv.TotalPrice)
 	// Balance = Total - AdvanceAdjusted = 25960.00 - 5000.00 = 20960.00

--- a/backend/internal/domain/gst/dto/gstr1.go
+++ b/backend/internal/domain/gst/dto/gstr1.go
@@ -17,7 +17,7 @@ type GSTR1Payload struct {
 
 // B2B Section
 type GSTR1B2B struct {
-	Ctin string       `json:"ctin"`
+	Ctin string        `json:"ctin"`
 	Inv  []GSTR1B2BInv `json:"inv"`
 }
 
@@ -47,19 +47,19 @@ type GSTR1TaxDetails struct {
 
 // CDNR Section
 type GSTR1CDNR struct {
-	Ctin string       `json:"ctin"`
+	Ctin string        `json:"ctin"`
 	Nt   []GSTR1CDNRNt `json:"nt"`
 }
 
 type GSTR1CDNRNt struct {
-	Ntty   string         `json:"ntty"` // "C" or "D"
-	NtNum  string         `json:"nt_num"`
-	NtDt   string         `json:"nt_dt"`
-	Inum   string         `json:"inum"`
-	Idt    string         `json:"idt"`
-	Val    float64        `json:"val"`
-	Pos    string         `json:"pos"`
-	Itms   []GSTR1TaxItem `json:"itms"`
+	Ntty  string         `json:"ntty"` // "C" or "D"
+	NtNum string         `json:"nt_num"`
+	NtDt  string         `json:"nt_dt"`
+	Inum  string         `json:"inum"`
+	Idt   string         `json:"idt"`
+	Val   float64        `json:"val"`
+	Pos   string         `json:"pos"`
+	Itms  []GSTR1TaxItem `json:"itms"`
 }
 
 // B2CSRow represents the consolidated B2C Small row in GSTR-1.


### PR DESCRIPTION
Appended proposal `[IDE-003] VIP Customer Segmentation & Automated Retention Loop` to `.jules/catalyst.md`. This proposal specifically targets the North Star Goal (3L/month) by leveraging existing `TotalSpent` and `TotalOrders` metrics in the `entity.Customer` model to automatically segment high-value users and drive repeat purchases via the SMM hub, effectively increasing AOV and LTV with zero CAC.

---
*PR created automatically by Jules for task [10189395623070802112](https://jules.google.com/task/10189395623070802112) started by @millennialperfumer-tech*