### PR TITLE
🎨 Palette: [a11y] Add ARIA labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 ## 2026-06-15 - [Icon-only Button Accessibility and Form Submission Prevention]
 **Learning:** Many interactive buttons in complex components like `AIAnalysis.tsx` missed `type="button"`, which could cause accidental form submissions if placed near forms. Additionally, utility buttons with only icons (like the send button or clear search) lacked `aria-label` attributes, impacting screen reader users.
 **Action:** Always add `type="button"` defensively to non-submit buttons and ensure explicit `aria-label` attributes on any icon-only interactive element.
+## 2026-06-25 - [Accessibility for Modals and Search Filters]
+**Learning:** Found multiple instances where utility 'close' or 'clear' icon buttons in modals and search inputs (e.g., `&times;` or `✕`) lacked `type="button"` and `aria-label`. Without these attributes, screen readers cannot communicate the button's function, and they may inadvertently trigger parent form submissions.
+**Action:** When creating or maintaining modals, popovers, and search bars, aggressively add `type="button"` and descriptive `aria-label` attributes to any icon-only interactive controls.

--- a/backend/internal/domain/b2b/entity/invoice.go
+++ b/backend/internal/domain/b2b/entity/invoice.go
@@ -20,15 +20,15 @@ type B2BInvoice struct {
 	Subject         *string    `gorm:"column:subject" json:"subject"`
 
 	// Customer snapshot fields (immutable historical details)
-	CustomerID        *int64  `gorm:"column:customer_id" json:"customer_id"`
-	CustomerGSTIN     string  `gorm:"column:customer_gstin" json:"customer_gstin"`
-	CustomerName      string  `gorm:"column:customer_name" json:"customer_name"`
-	CustomerEmail     *string `gorm:"column:customer_email" json:"customer_email"`
-	CustomerPhone     *string `gorm:"column:customer_phone" json:"customer_phone"`
-	CustomerState     string  `gorm:"column:customer_state" json:"customer_state"`
-	CustomerStateCode string  `gorm:"column:customer_state_code" json:"customer_state_code"`
-	CustomerAddress   string  `gorm:"column:customer_address" json:"customer_address"`
-	CustomerShippingAddress string `gorm:"column:customer_shipping_address" json:"customer_shipping_address"`
+	CustomerID              *int64  `gorm:"column:customer_id" json:"customer_id"`
+	CustomerGSTIN           string  `gorm:"column:customer_gstin" json:"customer_gstin"`
+	CustomerName            string  `gorm:"column:customer_name" json:"customer_name"`
+	CustomerEmail           *string `gorm:"column:customer_email" json:"customer_email"`
+	CustomerPhone           *string `gorm:"column:customer_phone" json:"customer_phone"`
+	CustomerState           string  `gorm:"column:customer_state" json:"customer_state"`
+	CustomerStateCode       string  `gorm:"column:customer_state_code" json:"customer_state_code"`
+	CustomerAddress         string  `gorm:"column:customer_address" json:"customer_address"`
+	CustomerShippingAddress string  `gorm:"column:customer_shipping_address" json:"customer_shipping_address"`
 
 	// Seller details snapshot
 	SellerGSTIN     string `gorm:"column:seller_gstin" json:"seller_gstin"`
@@ -67,12 +67,12 @@ type B2BInvoice struct {
 	PaymentDate   *time.Time `gorm:"column:payment_date" json:"payment_date"`
 	PaymentMethod *string    `gorm:"column:payment_method" json:"payment_method"`
 
-	CustomerNotes *string   `gorm:"column:customer_notes" json:"customer_notes"`
-	ProformaID    *int64    `gorm:"column:proforma_id" json:"proforma_id"`
-	AdvanceAdjusted float64 `gorm:"column:advance_adjusted" json:"advance_adjusted"`
-	InventoryDeducted bool `gorm:"column:inventory_deducted;default:false" json:"inventory_deducted"`
-	CreatedAt     time.Time `gorm:"column:created_at;default:NOW()" json:"created_at"`
-	UpdatedAt     time.Time `gorm:"column:updated_at;default:NOW()" json:"updated_at"`
+	CustomerNotes     *string   `gorm:"column:customer_notes" json:"customer_notes"`
+	ProformaID        *int64    `gorm:"column:proforma_id" json:"proforma_id"`
+	AdvanceAdjusted   float64   `gorm:"column:advance_adjusted" json:"advance_adjusted"`
+	InventoryDeducted bool      `gorm:"column:inventory_deducted;default:false" json:"inventory_deducted"`
+	CreatedAt         time.Time `gorm:"column:created_at;default:NOW()" json:"created_at"`
+	UpdatedAt         time.Time `gorm:"column:updated_at;default:NOW()" json:"updated_at"`
 
 	Items []B2BInvoiceItem `gorm:"foreignKey:InvoiceID" json:"items"`
 }
@@ -163,4 +163,3 @@ func parseFlexDate(s string) (time.Time, error) {
 	}
 	return time.Time{}, fmt.Errorf("invalid date format: %q", s)
 }
-

--- a/backend/internal/domain/b2b/entity/note.go
+++ b/backend/internal/domain/b2b/entity/note.go
@@ -6,14 +6,14 @@ import (
 
 // B2BCreditNote represents a B2B Credit Note
 type B2BCreditNote struct {
-	ID                 int64      `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
-	CreditNoteNumber   *string    `gorm:"column:credit_note_number;unique" json:"credit_note_number"`
-	CreditNoteSequence *int       `gorm:"column:credit_note_sequence" json:"credit_note_sequence"`
-	FinancialYear      *string    `gorm:"column:financial_year" json:"financial_year"`
-	InvoiceID          *int64     `gorm:"column:invoice_id" json:"invoice_id"`
-	InvoiceNumber      *string    `gorm:"column:invoice_number" json:"invoice_number"`
-	NoteDate           time.Time  `gorm:"column:note_date" json:"note_date"`
-	Reason             *string    `gorm:"column:reason" json:"reason"`
+	ID                 int64     `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	CreditNoteNumber   *string   `gorm:"column:credit_note_number;unique" json:"credit_note_number"`
+	CreditNoteSequence *int      `gorm:"column:credit_note_sequence" json:"credit_note_sequence"`
+	FinancialYear      *string   `gorm:"column:financial_year" json:"financial_year"`
+	InvoiceID          *int64    `gorm:"column:invoice_id" json:"invoice_id"`
+	InvoiceNumber      *string   `gorm:"column:invoice_number" json:"invoice_number"`
+	NoteDate           time.Time `gorm:"column:note_date" json:"note_date"`
+	Reason             *string   `gorm:"column:reason" json:"reason"`
 
 	// Customer snapshot
 	CustomerID        *int64  `gorm:"column:customer_id" json:"customer_id"`
@@ -79,14 +79,14 @@ func (B2BCreditNoteItem) TableName() string {
 
 // B2BDebitNote represents a B2B Debit Note
 type B2BDebitNote struct {
-	ID                int64      `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
-	DebitNoteNumber   *string    `gorm:"column:debit_note_number;unique" json:"debit_note_number"`
-	DebitNoteSequence *int       `gorm:"column:debit_note_sequence" json:"debit_note_sequence"`
-	FinancialYear     *string    `gorm:"column:financial_year" json:"financial_year"`
-	InvoiceID         *int64     `gorm:"column:invoice_id" json:"invoice_id"`
-	InvoiceNumber     *string    `gorm:"column:invoice_number" json:"invoice_number"`
-	NoteDate          time.Time  `gorm:"column:note_date" json:"note_date"`
-	Reason            *string    `gorm:"column:reason" json:"reason"`
+	ID                int64     `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	DebitNoteNumber   *string   `gorm:"column:debit_note_number;unique" json:"debit_note_number"`
+	DebitNoteSequence *int      `gorm:"column:debit_note_sequence" json:"debit_note_sequence"`
+	FinancialYear     *string   `gorm:"column:financial_year" json:"financial_year"`
+	InvoiceID         *int64    `gorm:"column:invoice_id" json:"invoice_id"`
+	InvoiceNumber     *string   `gorm:"column:invoice_number" json:"invoice_number"`
+	NoteDate          time.Time `gorm:"column:note_date" json:"note_date"`
+	Reason            *string   `gorm:"column:reason" json:"reason"`
 
 	// Customer snapshot
 	CustomerID        *int64  `gorm:"column:customer_id" json:"customer_id"`

--- a/backend/internal/domain/b2b/entity/proforma.go
+++ b/backend/internal/domain/b2b/entity/proforma.go
@@ -7,26 +7,26 @@ import (
 
 // B2BProformaInvoice represents a commercial proforma invoice
 type B2BProformaInvoice struct {
-	ID               int64                  `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
-	ProformaNumber   *string                `gorm:"column:proforma_number;unique" json:"proforma_number"`
-	ProformaSequence *int                   `gorm:"column:proforma_sequence" json:"proforma_sequence"`
-	FinancialYear    *string                `gorm:"column:financial_year" json:"financial_year"`
-	NoteDate         time.Time              `gorm:"column:note_date" json:"note_date"`
-	ValidUntil       *time.Time             `gorm:"column:valid_until" json:"valid_until"`
-	Status           string                 `gorm:"column:status;default:DRAFT" json:"status"` // DRAFT, SENT, ACCEPTED, CONVERTED_TO_INVOICE, REJECTED, EXPIRED, CANCELLED
-	RevisionNumber   int                    `gorm:"column:revision_number;default:1" json:"revision_number"`
-	ParentProformaID *int64                 `gorm:"column:parent_proforma_id" json:"parent_proforma_id"`
+	ID               int64      `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	ProformaNumber   *string    `gorm:"column:proforma_number;unique" json:"proforma_number"`
+	ProformaSequence *int       `gorm:"column:proforma_sequence" json:"proforma_sequence"`
+	FinancialYear    *string    `gorm:"column:financial_year" json:"financial_year"`
+	NoteDate         time.Time  `gorm:"column:note_date" json:"note_date"`
+	ValidUntil       *time.Time `gorm:"column:valid_until" json:"valid_until"`
+	Status           string     `gorm:"column:status;default:DRAFT" json:"status"` // DRAFT, SENT, ACCEPTED, CONVERTED_TO_INVOICE, REJECTED, EXPIRED, CANCELLED
+	RevisionNumber   int        `gorm:"column:revision_number;default:1" json:"revision_number"`
+	ParentProformaID *int64     `gorm:"column:parent_proforma_id" json:"parent_proforma_id"`
 
 	// Customer snapshot fields (immutable historical details)
-	CustomerID        *int64  `gorm:"column:customer_id" json:"customer_id"`
-	CustomerGSTIN     string  `gorm:"column:customer_gstin" json:"customer_gstin"`
-	CustomerName      string  `gorm:"column:customer_name" json:"customer_name"`
-	CustomerEmail     *string `gorm:"column:customer_email" json:"customer_email"`
-	CustomerPhone     *string `gorm:"column:customer_phone" json:"customer_phone"`
-	CustomerState     string  `gorm:"column:customer_state" json:"customer_state"`
-	CustomerStateCode string  `gorm:"column:customer_state_code" json:"customer_state_code"`
-	CustomerAddress   string  `gorm:"column:customer_address" json:"customer_address"`
-	CustomerShippingAddress string `gorm:"column:customer_shipping_address" json:"customer_shipping_address"`
+	CustomerID              *int64  `gorm:"column:customer_id" json:"customer_id"`
+	CustomerGSTIN           string  `gorm:"column:customer_gstin" json:"customer_gstin"`
+	CustomerName            string  `gorm:"column:customer_name" json:"customer_name"`
+	CustomerEmail           *string `gorm:"column:customer_email" json:"customer_email"`
+	CustomerPhone           *string `gorm:"column:customer_phone" json:"customer_phone"`
+	CustomerState           string  `gorm:"column:customer_state" json:"customer_state"`
+	CustomerStateCode       string  `gorm:"column:customer_state_code" json:"customer_state_code"`
+	CustomerAddress         string  `gorm:"column:customer_address" json:"customer_address"`
+	CustomerShippingAddress string  `gorm:"column:customer_shipping_address" json:"customer_shipping_address"`
 
 	// Seller details snapshot
 	SellerGSTIN     string `gorm:"column:seller_gstin" json:"seller_gstin"`
@@ -115,4 +115,3 @@ func (pf *B2BProformaInvoice) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
-

--- a/backend/internal/domain/b2b/handler/b2b_handler.go
+++ b/backend/internal/domain/b2b/handler/b2b_handler.go
@@ -819,4 +819,3 @@ func (h *B2BHandler) CheckExpiredProformas(w http.ResponseWriter, r *http.Reques
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{"status": "success", "expired_count": count})
 }
-

--- a/backend/internal/domain/b2b/repository/b2b_repository.go
+++ b/backend/internal/domain/b2b/repository/b2b_repository.go
@@ -145,7 +145,7 @@ func (r *gormB2BRepository) GetInvoiceByID(id int64) (entity.B2BInvoice, error) 
 
 func (r *gormB2BRepository) syncToOrdersTable(tx *gorm.DB, inv *entity.B2BInvoice) error {
 	extID := fmt.Sprintf("B2B-%d", inv.ID)
-	
+
 	// Check if order already exists
 	var orderID int64
 	err := tx.Table("orders").Where("source_id = ? AND external_order_id = ?", "b2b", extID).Pluck("id", &orderID).Error
@@ -163,7 +163,7 @@ func (r *gormB2BRepository) syncToOrdersTable(tx *gorm.DB, inv *entity.B2BInvoic
 	}
 
 	totalTax := inv.CGSTAmount + inv.SGSTAmount + inv.IGSTAmount
-	
+
 	orderNumber := extID
 	if inv.InvoiceNumber != nil && *inv.InvoiceNumber != "" {
 		orderNumber = *inv.InvoiceNumber
@@ -176,7 +176,7 @@ func (r *gormB2BRepository) syncToOrdersTable(tx *gorm.DB, inv *entity.B2BInvoic
 
 	orderData := map[string]interface{}{
 		"source_id":          "b2b",
-		"external_order_id":   extID,
+		"external_order_id":  extID,
 		"order_number":       orderNumber,
 		"invoice_number":     invoiceNumber,
 		"total_price":        inv.TotalPrice,
@@ -225,7 +225,7 @@ func (r *gormB2BRepository) syncToOrdersTable(tx *gorm.DB, inv *entity.B2BInvoic
 			if item.ID == 0 {
 				liID = fmt.Sprintf("b2b-%d-idx-%d", inv.ID, i)
 			}
-			
+
 			var productIDStr *string
 			if item.ProductID != nil {
 				s := fmt.Sprintf("%d", *item.ProductID)
@@ -664,5 +664,3 @@ func (r *gormB2BRepository) GetNextProformaSequenceForFY(fy string) (int, error)
 	err := row.Scan(&maxSeq)
 	return maxSeq + 1, err
 }
-
-

--- a/backend/internal/domain/b2b/service/proforma_b2b.go
+++ b/backend/internal/domain/b2b/service/proforma_b2b.go
@@ -113,14 +113,14 @@ func (s *B2BService) IssueProforma(id int64) (*entity.B2BProformaInvoice, error)
 
 		// Calculate number sequence
 		fy := helper.GetFinancialYear(pf.NoteDate)
-		
+
 		if pf.ParentProformaID != nil {
 			// It's a revision! Use parent's number and sequence with revision suffix
 			var parent entity.B2BProformaInvoice
 			if err := tx.First(&parent, *pf.ParentProformaID).Error; err != nil {
 				return fmt.Errorf("failed to fetch parent proforma: %w", err)
 			}
-			
+
 			parentNum := ""
 			if parent.ProformaNumber != nil {
 				parentNum = *parent.ProformaNumber
@@ -257,36 +257,36 @@ func (s *B2BService) CreateRevision(id int64) (*entity.B2BProformaInvoice, error
 		}
 
 		revision = entity.B2BProformaInvoice{
-			Status:            "DRAFT",
-			RevisionNumber:    int(count) + 1,
-			ParentProformaID:  &parentID,
-			NoteDate:          existing.NoteDate,
-			ValidUntil:        existing.ValidUntil,
-			CustomerID:        existing.CustomerID,
-			CustomerGSTIN:     existing.CustomerGSTIN,
-			CustomerName:      existing.CustomerName,
-			CustomerEmail:     existing.CustomerEmail,
-			CustomerPhone:     existing.CustomerPhone,
-			CustomerState:     existing.CustomerState,
-			CustomerStateCode: existing.CustomerStateCode,
-			CustomerAddress:   existing.CustomerAddress,
+			Status:                  "DRAFT",
+			RevisionNumber:          int(count) + 1,
+			ParentProformaID:        &parentID,
+			NoteDate:                existing.NoteDate,
+			ValidUntil:              existing.ValidUntil,
+			CustomerID:              existing.CustomerID,
+			CustomerGSTIN:           existing.CustomerGSTIN,
+			CustomerName:            existing.CustomerName,
+			CustomerEmail:           existing.CustomerEmail,
+			CustomerPhone:           existing.CustomerPhone,
+			CustomerState:           existing.CustomerState,
+			CustomerStateCode:       existing.CustomerStateCode,
+			CustomerAddress:         existing.CustomerAddress,
 			CustomerShippingAddress: existing.CustomerShippingAddress,
-			SellerGSTIN:       existing.SellerGSTIN,
-			SellerName:        existing.SellerName,
-			SellerState:       existing.SellerState,
-			SellerStateCode:   existing.SellerStateCode,
-			SellerAddress:     existing.SellerAddress,
-			SubtotalPrice:     existing.SubtotalPrice,
-			DiscountPercent:   existing.DiscountPercent,
-			DiscountAmount:    existing.DiscountAmount,
-			CGSTRate:          existing.CGSTRate,
-			CGSTAmount:        existing.CGSTAmount,
-			SGSTRate:          existing.SGSTRate,
-			SGSTAmount:        existing.SGSTAmount,
-			IGSTRate:          existing.IGSTRate,
-			IGSTAmount:        existing.IGSTAmount,
-			TotalPrice:        existing.TotalPrice,
-			AdvancePaid:       existing.AdvancePaid,
+			SellerGSTIN:             existing.SellerGSTIN,
+			SellerName:              existing.SellerName,
+			SellerState:             existing.SellerState,
+			SellerStateCode:         existing.SellerStateCode,
+			SellerAddress:           existing.SellerAddress,
+			SubtotalPrice:           existing.SubtotalPrice,
+			DiscountPercent:         existing.DiscountPercent,
+			DiscountAmount:          existing.DiscountAmount,
+			CGSTRate:                existing.CGSTRate,
+			CGSTAmount:              existing.CGSTAmount,
+			SGSTRate:                existing.SGSTRate,
+			SGSTAmount:              existing.SGSTAmount,
+			IGSTRate:                existing.IGSTRate,
+			IGSTAmount:              existing.IGSTAmount,
+			TotalPrice:              existing.TotalPrice,
+			AdvancePaid:             existing.AdvancePaid,
 		}
 
 		for _, item := range existing.Items {
@@ -338,35 +338,35 @@ func (s *B2BService) ConvertToTaxInvoice(id int64) (*entity.B2BInvoice, error) {
 
 		// Map to B2BInvoice
 		invoice = entity.B2BInvoice{
-			InvoiceDate:       time.Now(),
-			Status:            "DRAFT",
-			PaymentStatus:     "UNPAID",
-			CustomerID:        pf.CustomerID,
-			CustomerGSTIN:     pf.CustomerGSTIN,
-			CustomerName:      pf.CustomerName,
-			CustomerEmail:     pf.CustomerEmail,
-			CustomerPhone:     pf.CustomerPhone,
-			CustomerState:     pf.CustomerState,
-			CustomerStateCode: pf.CustomerStateCode,
-			CustomerAddress:   pf.CustomerAddress,
+			InvoiceDate:             time.Now(),
+			Status:                  "DRAFT",
+			PaymentStatus:           "UNPAID",
+			CustomerID:              pf.CustomerID,
+			CustomerGSTIN:           pf.CustomerGSTIN,
+			CustomerName:            pf.CustomerName,
+			CustomerEmail:           pf.CustomerEmail,
+			CustomerPhone:           pf.CustomerPhone,
+			CustomerState:           pf.CustomerState,
+			CustomerStateCode:       pf.CustomerStateCode,
+			CustomerAddress:         pf.CustomerAddress,
 			CustomerShippingAddress: pf.CustomerShippingAddress,
-			SellerGSTIN:       pf.SellerGSTIN,
-			SellerName:        pf.SellerName,
-			SellerState:       pf.SellerState,
-			SellerStateCode:   pf.SellerStateCode,
-			SellerAddress:     pf.SellerAddress,
-			SubtotalPrice:     pf.SubtotalPrice,
-			DiscountPercent:   pf.DiscountPercent,
-			DiscountAmount:    pf.DiscountAmount,
-			CGSTRate:          pf.CGSTRate,
-			CGSTAmount:        pf.CGSTAmount,
-			SGSTRate:          pf.SGSTRate,
-			SGSTAmount:        pf.SGSTAmount,
-			IGSTRate:          pf.IGSTRate,
-			IGSTAmount:        pf.IGSTAmount,
-			TotalPrice:        pf.TotalPrice,
-			ProformaID:        &pf.ID,
-			AdvanceAdjusted:   pf.AdvancePaid,
+			SellerGSTIN:             pf.SellerGSTIN,
+			SellerName:              pf.SellerName,
+			SellerState:             pf.SellerState,
+			SellerStateCode:         pf.SellerStateCode,
+			SellerAddress:           pf.SellerAddress,
+			SubtotalPrice:           pf.SubtotalPrice,
+			DiscountPercent:         pf.DiscountPercent,
+			DiscountAmount:          pf.DiscountAmount,
+			CGSTRate:                pf.CGSTRate,
+			CGSTAmount:              pf.CGSTAmount,
+			SGSTRate:                pf.SGSTRate,
+			SGSTAmount:              pf.SGSTAmount,
+			IGSTRate:                pf.IGSTRate,
+			IGSTAmount:              pf.IGSTAmount,
+			TotalPrice:              pf.TotalPrice,
+			ProformaID:              &pf.ID,
+			AdvanceAdjusted:         pf.AdvancePaid,
 		}
 
 		// Adjust BalanceAmount and PaymentStatus based on AdvancePaid

--- a/backend/internal/domain/b2b/test/b2b_service_test.go
+++ b/backend/internal/domain/b2b/test/b2b_service_test.go
@@ -298,7 +298,7 @@ func (s *B2BServiceTestSuite) TestInvoiceDeleteCascadesAndSync() {
 
 func (s *B2BServiceTestSuite) TestGSTPeriodLockUnlock() {
 	tDate := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
-	
+
 	// Ensure the test table is clean for this period
 	s.db.Exec("DELETE FROM gst_periods WHERE month = 6 AND year = 2026")
 
@@ -337,4 +337,3 @@ func (s *B2BServiceTestSuite) TestGSTPeriodLockUnlock() {
 func TestB2BServiceSuite(t *testing.T) {
 	suite.Run(t, new(B2BServiceTestSuite))
 }
-

--- a/backend/internal/domain/b2b/test/proforma_test.go
+++ b/backend/internal/domain/b2b/test/proforma_test.go
@@ -110,7 +110,6 @@ func (s *B2BProformaTestSuite) TestProformaLifecycle() {
 	s.db.Model(&entity.B2BProformaInvoice{}).Count(&pfCount)
 	assert.Equal(s.T(), int64(2), pfCount) // Must be exactly 2 (the parent/original and the revision)
 
-
 	// Issue revision
 	issuedRev, err := s.b2bService.IssueProforma(rev.ID)
 	assert.NoError(s.T(), err)
@@ -126,7 +125,7 @@ func (s *B2BProformaTestSuite) TestProformaLifecycle() {
 	assert.Equal(s.T(), "DRAFT", taxInv.Status)
 	assert.Equal(s.T(), issuedRev.ID, *taxInv.ProformaID)
 	assert.Equal(s.T(), 5000.00, taxInv.AdvanceAdjusted)
-	
+
 	// Total price = 22000 + 18% GST (3960) = 25960.00
 	assert.Equal(s.T(), 25960.00, taxInv.TotalPrice)
 	// Balance = Total - AdvanceAdjusted = 25960.00 - 5000.00 = 20960.00
@@ -186,4 +185,3 @@ func (s *B2BProformaTestSuite) TestProformaUnmarshal() {
 func TestB2BProformaSuite(t *testing.T) {
 	suite.Run(t, new(B2BProformaTestSuite))
 }
-

--- a/backend/internal/domain/gst/dto/gstr1.go
+++ b/backend/internal/domain/gst/dto/gstr1.go
@@ -93,10 +93,10 @@ type B2CSRow struct {
 
 // HSNWrapper encapsulates the bifurcated HSN lists.
 type HSNWrapper struct {
-	Flag   string   `json:"flag"`                 // "N"
-	HsnB2B []HSNRow `json:"hsn_b2b"`              // Table 12 B2B supplies
-	HsnB2C []HSNRow `json:"hsn_b2c"`              // Table 12 B2C supplies
-	Chksum string   `json:"chksum,omitempty"`     // Checksum
+	Flag   string   `json:"flag"`             // "N"
+	HsnB2B []HSNRow `json:"hsn_b2b"`          // Table 12 B2B supplies
+	HsnB2C []HSNRow `json:"hsn_b2c"`          // Table 12 B2C supplies
+	Chksum string   `json:"chksum,omitempty"` // Checksum
 }
 
 // HSNRow represents Table 12 rate-wise summary of outward supplies.
@@ -116,7 +116,7 @@ type HSNRow struct {
 
 // DocIssueWrapper encapsulates documents issued.
 type DocIssueWrapper struct {
-	Flag   string        `json:"flag"`             // "N"
+	Flag   string        `json:"flag"` // "N"
 	DocDet []DocCategory `json:"doc_det"`
 	Chksum string        `json:"chksum,omitempty"` // Checksum
 }

--- a/backend/internal/domain/gst/service/gst_service.go
+++ b/backend/internal/domain/gst/service/gst_service.go
@@ -427,7 +427,7 @@ func (s *GSTService) GetGSTR1JSON(startDate, endDate string, gstin string) (dto.
 	filDtStr := ""
 	endPeriod := parseISO(endDate)
 	if !endPeriod.IsZero() {
-		fp = endPeriod.Format("012006") // e.g. "062026"
+		fp = endPeriod.Format("012006")           // e.g. "062026"
 		filDtStr = endPeriod.Format("02-01-2006") // e.g. "30-06-2026"
 	} else {
 		// fallback to current month

--- a/frontend/src/B2BBills.tsx
+++ b/frontend/src/B2BBills.tsx
@@ -2074,7 +2074,7 @@ export function B2BBills({ fetchWithAuth, userRole = 'read', appConfigs = {} }: 
 										onChange={(e) => setInvoiceSearch(e.target.value)}
 									/>
 									{invoiceSearch && (
-										<button className="clear-search-btn" onClick={() => setInvoiceSearch('')}>✕</button>
+										<button type="button" aria-label="Clear search" className="clear-search-btn" onClick={() => setInvoiceSearch('')}>✕</button>
 									)}
 								</div>
 								<select
@@ -2497,7 +2497,7 @@ export function B2BBills({ fetchWithAuth, userRole = 'read', appConfigs = {} }: 
 										onChange={(e) => setProformaSearch(e.target.value)}
 									/>
 									{proformaSearch && (
-										<button className="clear-search-btn" onClick={() => setProformaSearch('')}>✕</button>
+										<button type="button" aria-label="Clear search" className="clear-search-btn" onClick={() => setProformaSearch('')}>✕</button>
 									)}
 								</div>
 								<select
@@ -2814,7 +2814,7 @@ export function B2BBills({ fetchWithAuth, userRole = 'read', appConfigs = {} }: 
 									onChange={(e) => setCustomerSearch(e.target.value)}
 								/>
 								{customerSearch && (
-									<button className="clear-search-btn" onClick={() => setCustomerSearch('')}>✕</button>
+									<button type="button" aria-label="Clear search" className="clear-search-btn" onClick={() => setCustomerSearch('')}>✕</button>
 								)}
 							</div>
 							{userRole === 'admin' && (
@@ -2928,7 +2928,7 @@ export function B2BBills({ fetchWithAuth, userRole = 'read', appConfigs = {} }: 
 										onChange={(e) => setCreditSearch(e.target.value)}
 									/>
 									{creditSearch && (
-										<button className="clear-search-btn" onClick={() => setCreditSearch('')}>✕</button>
+										<button type="button" aria-label="Clear search" className="clear-search-btn" onClick={() => setCreditSearch('')}>✕</button>
 									)}
 								</div>
 							</div>
@@ -3083,7 +3083,7 @@ export function B2BBills({ fetchWithAuth, userRole = 'read', appConfigs = {} }: 
 										onChange={(e) => setDebitSearch(e.target.value)}
 									/>
 									{debitSearch && (
-										<button className="clear-search-btn" onClick={() => setDebitSearch('')}>✕</button>
+										<button type="button" aria-label="Clear search" className="clear-search-btn" onClick={() => setDebitSearch('')}>✕</button>
 									)}
 								</div>
 							</div>
@@ -4258,6 +4258,8 @@ export function B2BBills({ fetchWithAuth, userRole = 'read', appConfigs = {} }: 
 												</td>
 												<td style={{ textAlign: 'center' }}>
 													<button
+														type="button"
+														aria-label="Remove item"
 														disabled={formProforma.items.length <= 1}
 														onClick={() => {
 															const newItems = formProforma.items.filter((_: any, i: number) => i !== idx);

--- a/frontend/src/CustomDatePicker.tsx
+++ b/frontend/src/CustomDatePicker.tsx
@@ -173,7 +173,7 @@ export const CustomDatePicker: React.FC<CustomDatePickerProps> = ({
           <div className="datepicker-modal-container">
             <div className="datepicker-modal-header">
               <h3>Select Date Range</h3>
-              <button className="modal-close-btn" onClick={handleCancel}>&times;</button>
+              <button type="button" aria-label="Close modal" className="modal-close-btn" onClick={handleCancel}>&times;</button>
             </div>
             
             <div className="datepicker-content">

--- a/frontend/src/Customers.tsx
+++ b/frontend/src/Customers.tsx
@@ -1532,7 +1532,7 @@ const BulkTemplateModal: React.FC<{
             <div className="modal-content" onClick={e => e.stopPropagation()} style={{ maxWidth: '600px', width: '90%' }}>
                 <div className="modal-header">
                     <h2 style={{ fontSize: '1.25rem', fontWeight: 700, color: 'var(--text-primary)' }}>Send Bulk Messages</h2>
-                    <button className="close-button" onClick={onClose}>&times;</button>
+                    <button type="button" aria-label="Close modal" className="close-button" onClick={onClose}>&times;</button>
                 </div>
 
                 <div className="modal-body" style={{ padding: '1.5rem' }}>

--- a/frontend/src/ManualWhatsAppModal.tsx
+++ b/frontend/src/ManualWhatsAppModal.tsx
@@ -110,7 +110,7 @@ export const ManualWhatsAppModal: React.FC<ManualWhatsAppModalProps> = ({
       <div className="modal-content" onClick={e => e.stopPropagation()} style={{ maxWidth: '600px', width: '90%' }}>
         <div className="modal-header">
           <h3>Send Webhook Notification</h3>
-          <button className="close-btn" onClick={onClose}>&times;</button>
+          <button type="button" aria-label="Close modal" className="close-btn" onClick={onClose}>&times;</button>
         </div>
         
         <div className="modal-body">

--- a/frontend/src/Products.tsx
+++ b/frontend/src/Products.tsx
@@ -855,7 +855,7 @@ export const Products: React.FC<{ token: string | null, userRole?: string, appCo
           }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.25rem', position: 'sticky', top: 0, background: 'var(--surface-color)', zIndex: 10, paddingBottom: '0.5rem' }}>
               <h3 style={{ margin: 0, fontSize: '1.1rem' }}>Product Specifications</h3>
-              <button className="toolbar-btn" onClick={() => setSelectedProduct(null)} style={{ fontSize: '1.2rem', padding: '0.5rem' }}>✕</button>
+              <button type="button" aria-label="Close" className="toolbar-btn" onClick={() => setSelectedProduct(null)} style={{ fontSize: '1.2rem', padding: '0.5rem' }}>✕</button>
             </div>
             
             <div style={{ display: 'grid', gap: '1.25rem' }}>
@@ -1074,7 +1074,7 @@ export const Products: React.FC<{ token: string | null, userRole?: string, appCo
                   {selectedProduct.title} ({selectedProduct.mi_sku})
                 </p>
               </div>
-              <button className="toolbar-btn" onClick={() => setShowLogsModal(false)}>✕</button>
+              <button type="button" aria-label="Close" className="toolbar-btn" onClick={() => setShowLogsModal(false)}>✕</button>
             </div>
 
             <div style={{ maxHeight: '450px', overflowY: 'auto', borderRadius: '12px', border: '1px solid var(--border-color)' }}>


### PR DESCRIPTION
💡 **What**: Added `type="button"` and `aria-label` attributes to 10 icon-only utility buttons (`✕` and `&times;`) across 5 frontend components (`B2BBills`, `Products`, `ManualWhatsAppModal`, `CustomDatePicker`, `Customers`).
🎯 **Why**: Improves accessibility for screen readers and acts defensively to prevent utility buttons from accidentally acting as submit buttons inside forms.
♿ **Accessibility**: Screen readers can now correctly interpret these buttons as "Clear search", "Remove item", or "Close modal".

Related to Palette UX standard: Add ARIA labels to icon-only buttons.

---
*PR created automatically by Jules for task [16066870401870498642](https://jules.google.com/task/16066870401870498642) started by @millennialperfumer-tech*