### PR TITLE
🎨 Palette: [Accessibility] Add type="button" and aria-label to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,7 @@
 ## 2026-06-25 - [Accessibility for Modals and Search Filters]
 **Learning:** Found multiple instances where utility 'close' or 'clear' icon buttons in modals and search inputs (e.g., `&times;` or `✕`) lacked `type="button"` and `aria-label`. Without these attributes, screen readers cannot communicate the button's function, and they may inadvertently trigger parent form submissions.
 **Action:** When creating or maintaining modals, popovers, and search bars, aggressively add `type="button"` and descriptive `aria-label` attributes to any icon-only interactive controls.
+
+## 2024-05-18 - Missing Type and ARIA labels on utility icon buttons
+**Learning:** Found a recurring pattern in React components where icon-only buttons (like those enclosing `svg` icons without text, e.g., in `App.tsx`, `MarketingDashboard.tsx`, `Planner.tsx`, `WhatsAppChat.tsx`, and `SettingsTab.tsx`) lacked explicit `type="button"` and semantic `aria-label`s. This lack of explicit type can cause unintentional form submissions in React context, and missing aria-labels hinder screen reader accessibility for vital actions.
+**Action:** Always verify that every `<button>` element containing only icon/svg elements explicitly declares `type="button"` (if not a submit button) and provides a clear `aria-label` (or dynamically generated label derived from the `title` attribute if suitable). Consider using a script or regex to audit `<button><svg/></button>` instances continuously to maintain a11y standards.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -792,7 +792,7 @@ function App() {
               transition: 'width 0.3s ease'
             }} 
           />
-          <button 
+          <button type="button"
             onClick={toggleSidebar}
             aria-label="Toggle sidebar"
             style={{ 
@@ -1011,7 +1011,7 @@ function App() {
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
                 )}
               </button>
-              <button
+              <button type="button"
                 onClick={handleLogout}
                 aria-label="Logout"
                 title="Sign Out"

--- a/frontend/src/MarketingDashboard.tsx
+++ b/frontend/src/MarketingDashboard.tsx
@@ -445,7 +445,7 @@ export const MarketingDashboard: React.FC<MarketingDashboardProps> = ({ fetchWit
                         </td>
                         <td style={{ padding: '1.4rem 1.8rem', textAlign: 'right', borderBottom: '1px solid var(--border-color)' }}>
                            <a href={`https://adsmanager.facebook.com/adsmanager/manage/campaigns?act=${metaData.activeId}&selected_campaign_ids=${camp.id}`} target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()}>
-                             <button className="toolbar-btn" style={{ padding: '8px' }} title="Change in Meta Dashboard">
+                             <button type="button" className="toolbar-btn" style={{ padding: '8px' }} title="Change in Meta Dashboard" aria-label="Change in Meta Dashboard">
                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--text-tertiary)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
                              </button>
                            </a>
@@ -554,7 +554,7 @@ export const MarketingDashboard: React.FC<MarketingDashboardProps> = ({ fetchWit
                         )}
                         <td style={{ padding: '1.2rem 1.8rem', textAlign: 'right', borderBottom: '1px solid var(--border-color)' }}>
                            <a href={`https://adsmanager.facebook.com/adsmanager/manage/ads?act=${metaData.activeId}&selected_ad_ids=${ad.id}`} target="_blank" rel="noreferrer">
-                             <button className="toolbar-btn" style={{ padding: '8px' }} title="Edit in Meta Dashboard">
+                             <button type="button" className="toolbar-btn" style={{ padding: '8px' }} title="Edit in Meta Dashboard" aria-label="Edit in Meta Dashboard">
                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--text-tertiary)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
                              </button>
                            </a>

--- a/frontend/src/Planner.tsx
+++ b/frontend/src/Planner.tsx
@@ -624,7 +624,7 @@ export const Planner: React.FC<PlannerProps> = ({ fetchWithAuth }) => {
         </div>
         
         <div style={{ display: 'flex', gap: '0.75rem' }}>
-          <button className="btn-secondary" style={{ padding: '0.6rem 1rem' }} onClick={loadAllData}>
+          <button type="button" className="btn-secondary" style={{ padding: '0.6rem 1rem' }} onClick={loadAllData} aria-label="Refresh planner data">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
           </button>
           <button 
@@ -873,7 +873,7 @@ export const Planner: React.FC<PlannerProps> = ({ fetchWithAuth }) => {
                       </h2>
                    </div>
                    {isEditing && (
-                      <button className="delete-btn-lux" onClick={handleDeleteTask}>
+                      <button type="button" className="delete-btn-lux" onClick={handleDeleteTask} aria-label="Delete task">
                           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
                       </button>
                    )}

--- a/frontend/src/SettingsTab.tsx
+++ b/frontend/src/SettingsTab.tsx
@@ -809,11 +809,12 @@ export function SettingsTab({ fetchWithAuth }: SettingsTabProps) {
                               >
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
                               </button>
-                              <button
+                              <button type="button"
                                 className="toolbar-btn"
                                 title="Cancel"
                                 onClick={handleCancelEdit}
                                 style={{ color: 'var(--status-error)' }}
+                                aria-label="Cancel edit"
                               >
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
                               </button>

--- a/frontend/src/WhatsAppChat.tsx
+++ b/frontend/src/WhatsAppChat.tsx
@@ -659,10 +659,11 @@ export function WhatsAppChat({ fetchWithAuth }: WhatsAppChatProps) {
                 onChange={(e) => setInputText(e.target.value)}
                 onKeyPress={(e) => e.key === 'Enter' && sendMessage()}
               />
-              <button 
+              <button type="button"
                 className="chat-send-btn" 
                 onClick={sendMessage}
                 disabled={!inputText.trim() || isSending || isUploadingMedia}
+                aria-label="Send message"
               >
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="22" y1="2" x2="11" y2="13"></line><polygon points="22 2 15 22 11 13 2 9 22 2"></polygon></svg>
               </button>


### PR DESCRIPTION
💡 What: Added `type="button"` and `aria-label`s to utility icon-only buttons across 5 core components (`App.tsx`, `MarketingDashboard.tsx`, `Planner.tsx`, `SettingsTab.tsx`, `WhatsAppChat.tsx`).
🎯 Why: Without explicit `type="button"`, buttons inside or near forms in React default to `submit`, causing accidental page reloads or unintended submissions. Without `aria-label`, these critical action buttons (like delete, sync, send, expand sidebar) are completely invisible/unusable to screen reader users.
📸 Before/After: Code-only change to `button` elements (e.g. `<button><svg/></button>` -> `<button type="button" aria-label="Action"><svg/></button>`).
♿ Accessibility: Ensures utility actions are reachable and properly communicated via screen readers, and prevents janky form submission behaviors.

---
*PR created automatically by Jules for task [2789025452092508886](https://jules.google.com/task/2789025452092508886) started by @millennialperfumer-tech*