### PR TITLE
🧪 [testing] Achieve 100% test coverage for AWS Signer

### DIFF
--- a/backend/internal/shared/extclient/amazon/signer_test.go
+++ b/backend/internal/shared/extclient/amazon/signer_test.go
@@ -222,4 +222,29 @@ func TestSignV4Edges(t *testing.T) {
 			t.Errorf("Expected Authorization header to be replaced with AWS4 signature, got %s", auth)
 		}
 	})
+
+	t.Run("req.URL.Host fallback", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "https://example-url-host.com", nil)
+		// Request automatically parses "https://example-url-host.com" into req.URL.Host
+		req.Host = ""
+		err := SignV4(req, nil, "AKID", "SECRET", "us-east-1", "s3", time.Now())
+		if err != nil {
+			t.Fatalf("SignV4 failed: %v", err)
+		}
+		if req.Header.Get("Host") != "example-url-host.com" {
+			t.Errorf("Expected Host to be set to example-url-host.com, got %s", req.Header.Get("Host"))
+		}
+	})
+
+	t.Run("Path with characters to escape", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "https://example.com/test path/!chars", nil)
+		err := SignV4(req, nil, "AKID", "SECRET", "us-east-1", "s3", time.Now())
+		if err != nil {
+			t.Fatalf("SignV4 failed: %v", err)
+		}
+		auth := req.Header.Get("Authorization")
+		if auth == "" {
+			t.Error("Expected Authorization header")
+		}
+	})
 }


### PR DESCRIPTION
### 🎯 What
The AWS SigV4 request signer (`backend/internal/shared/extclient/amazon/signer.go`) had missing test coverage for two specific edge cases:
- The `else` branch in `uriEscapePath` used when escaping characters not in the predefined unreserved list (like spaces or `!`).
- The fallback logic within `SignV4` that populates `req.Header.Set("Host", req.URL.Host)` when `req.Host` is unexpectedly empty.

### 📊 Coverage
Added two new deterministic test cases to the `TestSignV4Edges` block:
- `"req.URL.Host fallback"`: Verifies the correct `Host` header is applied when parsing URLs automatically populates `req.URL.Host` but leaves `req.Host` empty.
- `"Path with characters to escape"`: Verifies no panic and proper header addition when signing a path with characters like spaces and exclamation marks.

### ✨ Result
Statement coverage for `backend/internal/shared/extclient/amazon/signer.go` increased from 98.8% to 100.0%. Test suite regressions checked and passed.

---
*PR created automatically by Jules for task [3350157624082888047](https://jules.google.com/task/3350157624082888047) started by @millennialperfumer-tech*